### PR TITLE
Add workflow for publishing the rust crate on tag

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -1,0 +1,67 @@
+name: Release rust crate
+
+on:
+  push:
+    tags:
+      - "rust/v*"
+
+jobs:
+  runs-on: ubuntu-latest
+  get-version:
+    outputs:
+      version: ${{ steps.get-version.outputs.version }}
+    steps:
+      - name: Get version from tag
+        id: get-version
+        run: |
+          echo "using version tag ${GITHUB_REF:16}"
+          echo ::set-output name=version::${GITHUB_REF:16}
+  assert-matching-version:
+    needs: [get-version]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+      - name: Ensure version of crate matches release
+        id: get-cargo-version
+        run: |
+          CARGO_VERSION=$(cargo metadata --format-version 1 | jq '.packages[] | select( .name == "attestation-doc-validation" ) | .version')
+          if [ "$CARGO_VERSION" != "${{ env.TAG_VERSION }}" ]; then
+            echo "Version in tag does not match cargo.toml"
+            exit 1
+          fi
+        env:
+          TAG_VERSION: ${{ needs.get-version.outputs.version }}
+  # Before publishing, validate that all tests pass
+  run-ci-checks:
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install latest stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+          components: rustfmt, clippy
+      - uses: davidB/rust-cargo-make@10579dcff82285736fad5291533b52d3c93d6b3b
+      - name: Run CI Tasks with backtrace
+        run: cd attestation-doc-validation ; cargo make ci
+  dry-run-publish:
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+      - uses: davidB/rust-cargo-make@10579dcff82285736fad5291533b52d3c93d6b3b
+      - name: Package and Publish Cargo to registry
+        run: |
+          cargo login --token ${{ secrets.CARGO_AUTH_TOKEN }}
+          cd attestation-doc-validation
+          cargo publish --dry-run
+  publish-crate:
+    environment: public-release
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+      - uses: davidB/rust-cargo-make@10579dcff82285736fad5291533b52d3c93d6b3b
+      - name: Package and Publish Cargo to registry
+        run: |
+          cargo login --token ${{ secrets.CARGO_AUTH_TOKEN }}
+          cd attestation-doc-validation
+          cargo publish

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "attestation-doc-validation"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "aws-nitro-enclaves-cose",
  "aws-nitro-enclaves-nsm-api",

--- a/attestation-doc-validation/Cargo.toml
+++ b/attestation-doc-validation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "attestation-doc-validation"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "A Rust library for attesting enclaves according to the Evervault Attestation scheme. This crate is used to generate ffi bindings."


### PR DESCRIPTION
# Why
Need to be able to publish the rust crate to crates.io, so added a new workflow, and bumped the crate version to 0.4.0

# How
- On push to rust/v<semver>, we will deploy the rust crate to crates.io. While the tag pattern isn't the cleanest, we need to be able to release the crate in isolation, so we can update the dependencies of the bindings.
  - This pattern will extend to `node/v...` and `python/v...`
- The workflow does some validation on the crate before publishing
  - ensure the crate version matches the tag
  - ensure the tests are passing
  - perform a dry run publish
  - publish following additional approval
- The `public-release` environment is used to gate publishing to crates.io behind an additional approval by a member of @evervault/spectre 
