### PR TITLE
Clean quote returned from Cargo

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Ensure version of crate matches release
         id: get-cargo-version
         run: |
-          CARGO_VERSION=$(cargo metadata --format-version 1 | jq '.packages[] | select( .name == "attestation-doc-validation" ) | .version')
+          CARGO_VERSION=$(cargo metadata --format-version 1 | jq '.packages[] | select( .name == "attestation-doc-validation" ) | .version' | tr -d '"')
           if [ "$CARGO_VERSION" != "${{ env.TAG_VERSION }}" ]; then
             echo "Version in tag does not match cargo.toml"
             echo "Expected $CARGO_VERSION, Found ${{ env.TAG_VERSION }}"


### PR DESCRIPTION
# Why
The version tags aren't matching because the one returned from the cargo toml is in quotes

# How
Update action to strip quotes from the version to allow matching
