### PR TITLE
Correct passing of token to cargo

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -65,7 +65,7 @@ jobs:
       - uses: davidB/rust-cargo-make@10579dcff82285736fad5291533b52d3c93d6b3b
       - name: Package and Publish Cargo to registry
         run: |
-          cargo login --token ${{ secrets.CARGO_AUTH_TOKEN }}
+          cargo login -- --token ${{ secrets.CARGO_AUTH_TOKEN }}
           cd attestation-doc-validation
           cargo publish --dry-run
   publish-crate:
@@ -82,6 +82,6 @@ jobs:
       - uses: davidB/rust-cargo-make@10579dcff82285736fad5291533b52d3c93d6b3b
       - name: Package and Publish Cargo to registry
         run: |
-          cargo login --token ${{ secrets.CARGO_AUTH_TOKEN }}
+          cargo login -- --token ${{ secrets.CARGO_AUTH_TOKEN }}
           cd attestation-doc-validation
           cargo publish


### PR DESCRIPTION
# Why
Cargo doesn't expect the token to be passed directly to the login command

# How
Correct args
