### PR TITLE
Reduce length of cargo keywords

### DIFF
--- a/attestation-doc-validation/Cargo.toml
+++ b/attestation-doc-validation/Cargo.toml
@@ -8,7 +8,7 @@ homepage = "https://github.com/evervault/attestation-doc-validation"
 documentation = "https://github.com/evervault/attestation-doc-validation"
 repository = "https://github.com/evervault/attestation-doc-validation"
 readme = "README.md"
-keywords = ["aws", "nitro-enclaves", "confidential-computing", "attestation", "evervault"]
+keywords = ["aws", "nitro-enclaves", "enclaves", "attestation", "evervault"]
 categories = ["cryptography", "development-tools::ffi", "development-tools"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
# Why
Cargo restricts keywords to a max length of 20, confidetnial-computing is 22

# How
Remove confidential computing keyword, use enclaves