### PR TITLE
Remove transitive nix dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,6 +23,22 @@ dependencies = [
 [[package]]
 name = "attestation-doc-validation"
 version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8b657a11ef790cffece0c4e78a7043421e94599e58442920118f057e2892779"
+dependencies = [
+ "aws-nitro-enclaves-cose",
+ "aws-nitro-enclaves-nsm-api",
+ "base64 0.21.0",
+ "hex",
+ "openssl",
+ "serde_bytes",
+ "serde_cbor",
+ "thiserror",
+]
+
+[[package]]
+name = "attestation-doc-validation"
+version = "0.4.1"
 dependencies = [
  "aws-nitro-enclaves-cose",
  "base64 0.21.0",
@@ -34,22 +50,6 @@ dependencies = [
  "serde_cbor",
  "serde_json",
  "serde_with 2.2.0",
- "thiserror",
-]
-
-[[package]]
-name = "attestation-doc-validation"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8b657a11ef790cffece0c4e78a7043421e94599e58442920118f057e2892779"
-dependencies = [
- "aws-nitro-enclaves-cose",
- "aws-nitro-enclaves-nsm-api",
- "base64 0.21.0",
- "hex",
- "openssl",
- "serde_bytes",
- "serde_cbor",
  "thiserror",
 ]
 
@@ -466,7 +466,7 @@ dependencies = [
 name = "node-attestation-bindings"
 version = "0.0.0"
 dependencies = [
- "attestation-doc-validation 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "attestation-doc-validation 0.4.0",
  "napi",
  "napi-build",
  "napi-derive",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,11 +12,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "attestation-doc-validation"
 version = "0.4.0"
 dependencies = [
  "aws-nitro-enclaves-cose",
- "aws-nitro-enclaves-nsm-api",
  "base64 0.21.0",
  "hex",
  "openssl",
@@ -25,6 +33,7 @@ dependencies = [
  "serde_bytes",
  "serde_cbor",
  "serde_json",
+ "serde_with 2.2.0",
  "thiserror",
 ]
 
@@ -61,7 +70,7 @@ dependencies = [
  "serde_bytes",
  "serde_cbor",
  "serde_repr",
- "serde_with",
+ "serde_with 1.14.0",
 ]
 
 [[package]]
@@ -115,6 +124,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "chrono"
+version = "0.4.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16b0a3d9ed01224b22057780a37bb8c5dbfe1be8ba48678e7bf57ec4b385411f"
+dependencies = [
+ "iana-time-zone",
+ "num-integer",
+ "num-traits",
+ "serde",
+ "winapi",
+]
+
+[[package]]
+name = "codespan-reporting"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
+dependencies = [
+ "termcolor",
+ "unicode-width",
+]
+
+[[package]]
 name = "convert_case"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -122,6 +154,12 @@ checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
 dependencies = [
  "unicode-segmentation",
 ]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
 name = "ctor"
@@ -132,6 +170,91 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "cxx"
+version = "1.0.88"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "322296e2f2e5af4270b54df9e85a02ff037e271af20ba3e7fe1575515dc840b8"
+dependencies = [
+ "cc",
+ "cxxbridge-flags",
+ "cxxbridge-macro",
+ "link-cplusplus",
+]
+
+[[package]]
+name = "cxx-build"
+version = "1.0.88"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "017a1385b05d631e7875b1f151c9f012d37b53491e2a87f65bff5c262b2111d8"
+dependencies = [
+ "cc",
+ "codespan-reporting",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "scratch",
+ "syn",
+]
+
+[[package]]
+name = "cxxbridge-flags"
+version = "1.0.88"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c26bbb078acf09bc1ecda02d4223f03bdd28bd4874edcb0379138efc499ce971"
+
+[[package]]
+name = "cxxbridge-macro"
+version = "1.0.88"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357f40d1f06a24b60ae1fe122542c1fb05d28d32acb2aed064e84bc2ad1e252e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "darling"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0dd3cd20dc6b5a876612a6e5accfe7f3dd883db6d07acfbf14c128f61550dfa"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a784d2ccaf7c98501746bf0be29b2022ba41fd62a2e622af997a03e9f972859f"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7618812407e9402654622dd402b0a89dff9ba93badd6540781526117b92aab7e"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foreign-types"
@@ -155,10 +278,57 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
 
 [[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64c122667b287044802d6ce17ee2ddf13207ed924c712de9a66a5814d5b64765"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "winapi",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0703ae284fc167426161c2e3f1da3ea71d94b21bedbcc9494e92b28e334e3dca"
+dependencies = [
+ "cxx",
+ "cxx-build",
+]
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "indexmap"
+version = "1.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
+dependencies = [
+ "autocfg",
+ "hashbrown",
+ "serde",
+]
 
 [[package]]
 name = "itoa"
@@ -189,6 +359,15 @@ checksum = "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f"
 dependencies = [
  "cfg-if",
  "winapi",
+]
+
+[[package]]
+name = "link-cplusplus"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecd207c9c713c34f95a097a5b029ac2ce6010530c7b49d7fea24d977dede04f5"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -291,6 +470,25 @@ dependencies = [
  "napi",
  "napi-build",
  "napi-derive",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
+dependencies = [
+ "autocfg",
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -422,6 +620,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b4b9743ed687d4b4bcedf9ff5eaa7398495ae14e61cba0a295704edbc7decde"
 
 [[package]]
+name = "scratch"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddccb15bcce173023b3fedd9436f882a0739b8dfb45e4f6b6002bee5929f61b2"
+
+[[package]]
 name = "serde"
 version = "1.0.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -492,10 +696,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_with"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d904179146de381af4c93d3af6ca4984b3152db687dacb9c3c35e86f39809c"
+dependencies = [
+ "base64 0.13.1",
+ "chrono",
+ "hex",
+ "indexmap",
+ "serde",
+ "serde_json",
+ "serde_with_macros",
+ "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1966009f3c05f095697c537312f5415d1e3ed31ce0a56942bac4c771c5c335e"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+
+[[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
@@ -506,6 +744,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -543,8 +790,10 @@ version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a561bf4617eebd33bca6434b988f39ed798e527f51a1e797d0ee4f61c0a38376"
 dependencies = [
+ "itoa",
  "serde",
  "time-core",
+ "time-macros",
 ]
 
 [[package]]
@@ -552,6 +801,15 @@ name = "time-core"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
+
+[[package]]
+name = "time-macros"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d967f99f534ca7e495c575c62638eebc2898a8c84c119b89e250477bc4ba16b2"
+dependencies = [
+ "time-core",
+]
 
 [[package]]
 name = "unicode-ident"
@@ -564,6 +822,12 @@ name = "unicode-segmentation"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fdbf052a0783de01e944a6ce7a8cb939e295b1e7be835a1112c3b9a7f047a5a"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 
 [[package]]
 name = "untrusted"
@@ -656,6 +920,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/attestation-doc-validation/Cargo.toml
+++ b/attestation-doc-validation/Cargo.toml
@@ -15,13 +15,14 @@ categories = ["cryptography", "development-tools::ffi", "development-tools"]
 
 [dependencies]
 aws-nitro-enclaves-cose = "0.5.0"
-aws-nitro-enclaves-nsm-api = "0.2.1"
 openssl = "0.10.41"
 thiserror = "1.0"
 serde_cbor = "0.11"
 hex = "0.4.3"
 base64 = "0.21"
 serde_bytes = "0.11"
+serde = { version = "1.0", features = ["derive"] }
+serde_with = "2.2"
 
 [dev-dependencies]
 rcgen = "0.10"

--- a/attestation-doc-validation/Cargo.toml
+++ b/attestation-doc-validation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "attestation-doc-validation"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 license = "Apache-2.0"
 description = "A Rust library for attesting enclaves according to the Evervault Attestation scheme. This crate is used to generate ffi bindings."

--- a/attestation-doc-validation/src/attestation_doc.rs
+++ b/attestation-doc-validation/src/attestation_doc.rs
@@ -1,10 +1,10 @@
 //! Module for parsing and validating attestation documents from AWS Nitro Enclaves.
+use super::nsm::nsm_api::{AttestationDoc, Digest};
 use super::{
     error::{AttestationDocError, AttestationDocResult},
     true_or_invalid,
 };
 pub(super) use aws_nitro_enclaves_cose::CoseSign1;
-use super::nsm::nsm_api::{AttestationDoc, Digest};
 use base64::Engine;
 use openssl::pkey::{PKey, Public};
 use std::collections::BTreeMap;

--- a/attestation-doc-validation/src/attestation_doc.rs
+++ b/attestation-doc-validation/src/attestation_doc.rs
@@ -4,8 +4,7 @@ use super::{
     true_or_invalid,
 };
 pub(super) use aws_nitro_enclaves_cose::CoseSign1;
-pub(super) use aws_nitro_enclaves_nsm_api::api::AttestationDoc;
-use aws_nitro_enclaves_nsm_api::api::Digest;
+use super::nsm::nsm_api::{AttestationDoc, Digest};
 use base64::Engine;
 use openssl::pkey::{PKey, Public};
 use std::collections::BTreeMap;

--- a/attestation-doc-validation/src/lib.rs
+++ b/attestation-doc-validation/src/lib.rs
@@ -1,8 +1,9 @@
 pub mod attestation_doc;
 pub mod cert;
 pub mod error;
+mod nsm;
 
-use attestation_doc::AttestationDoc;
+use nsm::nsm_api::AttestationDoc;
 use openssl::x509::X509;
 
 // Helper function to fail early on any variant of error::AttestError

--- a/attestation-doc-validation/src/nsm/error.rs
+++ b/attestation-doc-validation/src/nsm/error.rs
@@ -25,5 +25,5 @@ pub enum NsmError {
     #[error("Tag was missing or invalid: {0:?}")]
     TagError(Option<u64>),
     #[error("Failed to perform an encryption operation")]
-    EncryptionError(Box<dyn std::error::Error>)
+    EncryptionError(Box<dyn std::error::Error>),
 }

--- a/attestation-doc-validation/src/nsm/error.rs
+++ b/attestation-doc-validation/src/nsm/error.rs
@@ -1,0 +1,29 @@
+use thiserror::Error;
+
+pub type NsmResult<T> = std::result::Result<T, NsmError>;
+
+/// Wrapping type to record the specific error that occurred while processing the encoded attestation doc.
+#[allow(clippy::module_name_repetitions)]
+#[derive(Error, Debug)]
+pub enum NsmError {
+    #[error("Failed to obtain sufficient entropy")]
+    EntropyError(Box<dyn std::error::Error>),
+    #[error("Failed to compute hash")]
+    HashingError(Box<dyn std::error::Error>),
+    #[error("Unimplemented code path hit.")]
+    UnimplementedError,
+    #[error("Unsupported: {0}")]
+    UnsupportedError(String),
+    #[error("An error occurred while decoding the attestation from CBOR — {0}")]
+    Cbor(#[from] serde_cbor::Error),
+    #[error("Failed to verify signature")]
+    UnverifiedSignature,
+    #[error("Failed to perform signature")]
+    SignatureError(Box<dyn std::error::Error>),
+    #[error("Specification violated - {0}")]
+    SpecificationError(String),
+    #[error("Tag was missing or invalid: {0:?}")]
+    TagError(Option<u64>),
+    #[error("Failed to perform an encryption operation")]
+    EncryptionError(Box<dyn std::error::Error>)
+}

--- a/attestation-doc-validation/src/nsm/mod.rs
+++ b/attestation-doc-validation/src/nsm/mod.rs
@@ -1,2 +1,2 @@
-pub(super) mod nsm_api;
 pub(super) mod error;
+pub(super) mod nsm_api;

--- a/attestation-doc-validation/src/nsm/mod.rs
+++ b/attestation-doc-validation/src/nsm/mod.rs
@@ -1,0 +1,2 @@
+pub(super) mod nsm_api;
+pub(super) mod error;

--- a/attestation-doc-validation/src/nsm/nsm_api.rs
+++ b/attestation-doc-validation/src/nsm/nsm_api.rs
@@ -51,20 +51,20 @@ pub struct AttestationDoc {
 }
 
 impl AttestationDoc {
-    /// Creates a new AttestationDoc.
+    /// Creates a new `AttestationDoc`.
     ///
     /// # Arguments
     ///
-    /// * module_id: a String representing the name of the NitroSecureModule
-    /// * digest: nsm_io::Digest that describes what the PlatformConfigurationRegisters
+    /// * `module_id`: a String representing the name of the `NitroSecureModule`
+    /// * digest: `nsm_io::Digest` that describes what the `PlatformConfigurationRegisters`
     ///           contain
-    /// * pcrs: BTreeMap containing the index to PCR value
-    /// * certificate: the serialized certificate that will be used to sign this AttestationDoc
+    /// * pcrs: `BTreeMap` containing the index to PCR value
+    /// * certificate: the serialized certificate that will be used to sign this `AttestationDoc`
     /// * cabundle: the serialized set of certificates up to the root of trust certificate that
     ///             emitted `certificate`
-    /// * user_data: optional user definted data included in the AttestationDoc
-    /// * nonce: optional cryptographic nonce that will be included in the AttestationDoc
-    /// * public_key: optional DER-encoded public key that will be included in the AttestationDoc
+    /// * `user_data`: optional user definted data included in the `AttestationDoc`
+    /// * nonce: optional cryptographic nonce that will be included in the `AttestationDoc`
+    /// * `public_key`: optional DER-encoded public key that will be included in the `AttestationDoc`
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         module_id: String,
@@ -79,7 +79,7 @@ impl AttestationDoc {
     ) -> Self {
         let mut pcrs_serialized = BTreeMap::new();
 
-        for (i, pcr) in pcrs.into_iter() {
+        for (i, pcr) in pcrs {
             let pcr = ByteBuf::from(pcr);
             pcrs_serialized.insert(i, pcr);
         }
@@ -99,13 +99,13 @@ impl AttestationDoc {
         }
     }
 
-    /// Helper function that converts an AttestationDoc structure to its CBOR representation
+    /// Helper function that converts an `AttestationDoc` structure to its CBOR representation
     pub fn to_binary(&self) -> Vec<u8> {
         // This should not fail
         to_vec(self).unwrap()
     }
 
-    /// Helper function that parses a CBOR representation of an AttestationDoc and creates the
+    /// Helper function that parses a CBOR representation of an `AttestationDoc` and creates the
     /// structure from it, if possible.
     pub fn from_binary(bin: &[u8]) -> NsmResult<Self> {
         from_slice(bin).map_err(NsmError::Cbor)

--- a/attestation-doc-validation/src/nsm/nsm_api.rs
+++ b/attestation-doc-validation/src/nsm/nsm_api.rs
@@ -1,0 +1,113 @@
+use super::error::{NsmError, NsmResult};
+use serde::{Deserialize, Serialize};
+/// Collection of structs and trait impls to act as a compatability layer with the AWS NSM crates
+use serde_bytes::ByteBuf;
+use serde_cbor::{from_slice, to_vec};
+use std::collections::BTreeMap;
+
+// Compatability for [aws_nitro_enclaves_nsm_api](https://docs.rs/aws-nitro-enclaves-nsm-api/0.2.1/aws_nitro_enclaves_nsm_api/index.html)
+
+#[derive(Debug, Serialize, Deserialize, Copy, Clone, PartialEq)]
+pub enum Digest {
+    /// SHA256
+    SHA256,
+    /// SHA384
+    SHA384,
+    /// SHA512
+    SHA512,
+}
+
+/// An attestation response.  This is also used for sealing
+/// data.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub struct AttestationDoc {
+    /// Issuing NSM ID
+    pub module_id: String,
+
+    /// The digest function used for calculating the register values
+    /// Can be: "SHA256" | "SHA512"
+    pub digest: Digest,
+
+    /// UTC time when document was created expressed as milliseconds since Unix Epoch
+    pub timestamp: u64,
+
+    /// Map of all locked PCRs at the moment the attestation document was generated
+    pub pcrs: BTreeMap<usize, ByteBuf>,
+
+    /// The infrastucture certificate used to sign the document, DER encoded
+    pub certificate: ByteBuf,
+    /// Issuing CA bundle for infrastructure certificate
+    pub cabundle: Vec<ByteBuf>,
+
+    /// An optional DER-encoded key the attestation consumer can use to encrypt data with
+    pub public_key: Option<ByteBuf>,
+
+    /// Additional signed user data, as defined by protocol.
+    pub user_data: Option<ByteBuf>,
+
+    /// An optional cryptographic nonce provided by the attestation consumer as a proof of
+    /// authenticity.
+    pub nonce: Option<ByteBuf>,
+}
+
+impl AttestationDoc {
+    /// Creates a new AttestationDoc.
+    ///
+    /// # Arguments
+    ///
+    /// * module_id: a String representing the name of the NitroSecureModule
+    /// * digest: nsm_io::Digest that describes what the PlatformConfigurationRegisters
+    ///           contain
+    /// * pcrs: BTreeMap containing the index to PCR value
+    /// * certificate: the serialized certificate that will be used to sign this AttestationDoc
+    /// * cabundle: the serialized set of certificates up to the root of trust certificate that
+    ///             emitted `certificate`
+    /// * user_data: optional user definted data included in the AttestationDoc
+    /// * nonce: optional cryptographic nonce that will be included in the AttestationDoc
+    /// * public_key: optional DER-encoded public key that will be included in the AttestationDoc
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        module_id: String,
+        digest: Digest,
+        timestamp: u64,
+        pcrs: BTreeMap<usize, Vec<u8>>,
+        certificate: Vec<u8>,
+        cabundle: Vec<Vec<u8>>,
+        user_data: Option<Vec<u8>>,
+        nonce: Option<Vec<u8>>,
+        public_key: Option<Vec<u8>>,
+    ) -> Self {
+        let mut pcrs_serialized = BTreeMap::new();
+
+        for (i, pcr) in pcrs.into_iter() {
+            let pcr = ByteBuf::from(pcr);
+            pcrs_serialized.insert(i, pcr);
+        }
+
+        let cabundle_serialized = cabundle.into_iter().map(ByteBuf::from).collect();
+
+        AttestationDoc {
+            module_id,
+            digest,
+            timestamp,
+            pcrs: pcrs_serialized,
+            cabundle: cabundle_serialized,
+            certificate: ByteBuf::from(certificate),
+            user_data: user_data.map(ByteBuf::from),
+            nonce: nonce.map(ByteBuf::from),
+            public_key: public_key.map(ByteBuf::from),
+        }
+    }
+
+    /// Helper function that converts an AttestationDoc structure to its CBOR representation
+    pub fn to_binary(&self) -> Vec<u8> {
+        // This should not fail
+        to_vec(self).unwrap()
+    }
+
+    /// Helper function that parses a CBOR representation of an AttestationDoc and creates the
+    /// structure from it, if possible.
+    pub fn from_binary(bin: &[u8]) -> NsmResult<Self> {
+        from_slice(bin).map_err(NsmError::Cbor)
+    }
+}


### PR DESCRIPTION
# Why
We can recreate the types we need from the nsm api without a direct dependency which will remove a transitive dependency on nix

# How
Recreate the types that we depend on from the nsm api and remove the dep
