### PR TITLE
Make attestation doc functions public

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,9 +113,9 @@ checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
 
 [[package]]
 name = "cc"
-version = "1.0.78"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a20104e2335ce8a659d6dd92a51a767a0c062599c73b343fd152cb401e828c3d"
+checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
 
 [[package]]
 name = "cfg-if"
@@ -338,9 +338,9 @@ checksum = "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
 
 [[package]]
 name = "js-sys"
-version = "0.3.60"
+version = "0.3.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49409df3e3bf0856b916e2ceaca09ee28e6871cf7d9ce97a692cacfdb2a25a47"
+checksum = "445dde2150c55e483f3d8416706b97ec8e8237c307e5b7b4b8dd15e6af2a0730"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -396,9 +396,9 @@ dependencies = [
 
 [[package]]
 name = "napi"
-version = "2.10.8"
+version = "2.10.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562f120c9cb0828791508b7a2baed409490b60e380ba46f825978be212b25ae1"
+checksum = "a6d58a7870622e4351385b9987a87476efda841e0a2cf66e7bbd01a79ec2e5f5"
 dependencies = [
  "bitflags",
  "ctor",
@@ -415,9 +415,9 @@ checksum = "882a73d9ef23e8dc2ebbffb6a6ae2ef467c0f18ac10711e4cc59c5485d41df0e"
 
 [[package]]
 name = "napi-derive"
-version = "2.9.5"
+version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47bff5a8ed70117bce55053a74ff8f423f90c48c704030609272e6e3bde1c5a4"
+checksum = "4f73dd4ddd118bd87756c72fead4c727dc4ee6ba3af3cd98d8490eb09b5a8573"
 dependencies = [
  "convert_case",
  "napi-derive-backend",
@@ -428,9 +428,9 @@ dependencies = [
 
 [[package]]
 name = "napi-derive-backend"
-version = "1.0.41"
+version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13b412301aeebee17724fff6d73536e9ecb8387f10bbbf317a9f7a006cc1c5b"
+checksum = "57e4e6bb1ee73ec3938a8dfd2ce81955954b8e48c3a40c839918a9735feb0d61"
 dependencies = [
  "convert_case",
  "once_cell",
@@ -442,9 +442,9 @@ dependencies = [
 
 [[package]]
 name = "napi-sys"
-version = "2.2.2"
+version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "529671ebfae679f2ce9630b62dd53c72c56b3eb8b2c852e7e2fa91704ff93d67"
+checksum = "166b5ef52a3ab5575047a9fe8d4a030cdd0f63c96f071cd6907674453b07bae3"
 dependencies = [
  "libloading",
 ]
@@ -819,9 +819,9 @@ checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.10.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fdbf052a0783de01e944a6ce7a8cb939e295b1e7be835a1112c3b9a7f047a5a"
+checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
 
 [[package]]
 name = "unicode-width"
@@ -843,9 +843,9 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaf9f5aceeec8be17c128b2e93e031fb8a4d469bb9c4ae2d7dc1888b26887268"
+checksum = "31f8dcbc21f30d9b8f2ea926ecb58f6b91192c17e9d33594b3df58b2007ca53b"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -853,9 +853,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c8ffb332579b0557b52d268b91feab8df3615f265d5270fec2a8c95b17c1142"
+checksum = "95ce90fd5bcc06af55a641a86428ee4229e44e07033963a2290a8e241607ccb9"
 dependencies = [
  "bumpalo",
  "log",
@@ -868,9 +868,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "052be0f94026e6cbc75cdefc9bae13fd6052cdcaf532fa6c45e7ae33a1e6c810"
+checksum = "4c21f77c0bedc37fd5dc21f897894a5ca01e7bb159884559461862ae90c0b4c5"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -878,9 +878,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bc0c051dc5f23e307b13285f9d75df86bfdf816c5721e573dec1f9b8aa193c"
+checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -891,15 +891,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c38c045535d93ec4f0b4defec448e4291638ee608530863b1e2ba115d4fff7f"
+checksum = "0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d"
 
 [[package]]
 name = "web-sys"
-version = "0.3.60"
+version = "0.3.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcda906d8be16e728fd5adc5b729afad4e444e106ab28cd1c7256e54fa61510f"
+checksum = "e33b99f4b23ba3eec1a53ac264e35a755f00e966e0065077d6027c0f575b0b97"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/attestation-doc-validation/src/attestation_doc.rs
+++ b/attestation-doc-validation/src/attestation_doc.rs
@@ -145,19 +145,30 @@ pub fn validate_expected_nonce<T: PCRProvider>(
     )
 }
 
-pub(super) fn validate_cose_signature(
+/// Takes a public key and attestation doc in `CoseSign1` form and returns a result based on it's validity
+///
+/// # Errors
+///
+/// Returns a `InvalidCoseSignature` error if signature is invalid
+pub fn validate_cose_signature(
     signing_cert_public_key: &PKey<Public>,
     cose_sign_1_decoded: &CoseSign1,
 ) -> AttestationDocResult<()> {
     true_or_invalid(
         cose_sign_1_decoded
             .verify_signature::<aws_nitro_enclaves_cose::crypto::Openssl>(signing_cert_public_key)
-            .map_err(|err| AttestationDocError::Cose(err.to_string()))?,
+            .map_err(|err| AttestationDocError::InvalidCose(err.to_string()))?,
         AttestationDocError::InvalidCoseSignature,
     )
 }
 
-pub(super) fn validate_expected_challenge(
+/// Takes an `AttestationDoc` and expected challenge and compares them
+///
+/// # Errors
+///
+/// Returns a `MissingUserData` error if user data is not present in attestation doc
+/// Returns a `UserDataMismatch` error if the challenges do not match
+pub fn validate_expected_challenge(
     attestation_doc: &AttestationDoc,
     expected_challenge: &[u8],
 ) -> AttestationDocResult<()> {
@@ -171,7 +182,24 @@ pub(super) fn validate_expected_challenge(
     )
 }
 
-/// Derived from [AWS attestation process](https://github.com/aws/aws-nitro-enclaves-nsm-api/blob/main/docs/attestation_process.md)
+/// Takes a byte array and parses is as an `AttestationDoc` and `CoseSign1`
+///
+/// # Errors
+///
+/// Returns a `InvalidCose` if the byte array can't be parsed as a `CoseSign1`
+/// Returns a `DocStructureInvalid` if the attestation doc doesn't follow the [AWS criteria](https://github.com/aws/aws-nitro-enclaves-nsm-api/blob/main/docs/attestation_process.md)
+pub fn decode_attestation_document(
+    cose_sign_1_bytes: &[u8],
+) -> AttestationDocResult<(CoseSign1, AttestationDoc)> {
+    let cose_sign_1_decoded: CoseSign1 = serde_cbor::from_slice(cose_sign_1_bytes)?;
+    let cbor = cose_sign_1_decoded
+        .get_payload::<aws_nitro_enclaves_cose::crypto::Openssl>(None)
+        .map_err(|err| AttestationDocError::InvalidCose(err.to_string()))?;
+    let attestation_doc: AttestationDoc = serde_cbor::from_slice(&cbor)?;
+    validate_attestation_document_structure(&attestation_doc)?;
+    Ok((cose_sign_1_decoded, attestation_doc))
+}
+
 pub(super) fn validate_attestation_document_structure(
     attestation_document: &AttestationDoc,
 ) -> AttestationDocResult<()> {
@@ -204,17 +232,7 @@ pub(super) fn validate_attestation_document_structure(
         .user_data
         .as_ref()
         .map_or(true, |user_data| user_data.len() > 0 && user_data.len() <= 512);
-    true_or_invalid(valid_structure_check, AttestationDocError::DocStructure)
-}
-
-pub(super) fn decode_attestation_document(
-    cose_sign_1_bytes: &[u8],
-) -> AttestationDocResult<(CoseSign1, AttestationDoc)> {
-    let cose_sign_1_decoded: CoseSign1 = serde_cbor::from_slice(cose_sign_1_bytes)?;
-    let cbor = cose_sign_1_decoded
-        .get_payload::<aws_nitro_enclaves_cose::crypto::Openssl>(None)
-        .map_err(|err| AttestationDocError::Cose(err.to_string()))?;
-    Ok((cose_sign_1_decoded, serde_cbor::from_slice(&cbor)?))
+    true_or_invalid(valid_structure_check, AttestationDocError::DocStructureInvalid)
 }
 
 #[cfg(test)]

--- a/attestation-doc-validation/src/attestation_doc.rs
+++ b/attestation-doc-validation/src/attestation_doc.rs
@@ -232,7 +232,10 @@ pub(super) fn validate_attestation_document_structure(
         .user_data
         .as_ref()
         .map_or(true, |user_data| user_data.len() > 0 && user_data.len() <= 512);
-    true_or_invalid(valid_structure_check, AttestationDocError::DocStructureInvalid)
+    true_or_invalid(
+        valid_structure_check,
+        AttestationDocError::DocStructureInvalid,
+    )
 }
 
 #[cfg(test)]

--- a/attestation-doc-validation/src/error.rs
+++ b/attestation-doc-validation/src/error.rs
@@ -29,11 +29,11 @@ where
     Self: Send + Sync,
 {
     #[error("COSE error: `{0}`")]
-    Cose(String),
+    InvalidCose(String),
     #[error(transparent)]
-    Cbor(#[from] serde_cbor::error::Error),
+    InvalidCbor(#[from] serde_cbor::error::Error),
     #[error("A part of the attestation doc structure was deemed invalid")]
-    DocStructure,
+    DocStructureInvalid,
     #[error("The COSE signature does not match the public key provided in the attestation doc")]
     InvalidCoseSignature,
     #[error(


### PR DESCRIPTION
# Why
Need attestation doc parsing and challenge validation public for use in E3

# How
- Make functions public
- Move validation into `decode_attestation_document` and keep private
