### PR TITLE
Add --no-dep to cargo metadata for rust release

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Ensure version of crate matches release
         id: get-cargo-version
         run: |
-          CARGO_VERSION=$(cargo metadata --format-version 1 | jq '.packages[] | select( .name == "attestation-doc-validation" ) | .version' | tr -d '"')
+          CARGO_VERSION=$(cargo metadata --no-deps --format-version 1 | jq '.packages[] | select( .name == "attestation-doc-validation" ) | .version' | tr -d '"')
           if [ "$CARGO_VERSION" != "${{ env.TAG_VERSION }}" ]; then
             echo "Version in tag does not match cargo.toml"
             echo "Expected $CARGO_VERSION, Found ${{ env.TAG_VERSION }}"


### PR DESCRIPTION
# Why
Release is breaking at the moment due to a dependency version mismatch

# How
Don't include dependencies in cargo metadata command
