### PR TITLE
Validate any attestation doc and parse PCRs easily

### DIFF
--- a/attestation-doc-validation/src/attestation_doc.rs
+++ b/attestation-doc-validation/src/attestation_doc.rs
@@ -93,7 +93,7 @@ impl PCRProvider for PCRs {
 ///
 /// # Errors
 ///
-/// Returns an error if any of the expected PCRs are missing from the attestation document, or if the expected PCRs don't match the values embedded in the doc
+/// Returns an error if any of the expected PCRs are missing from the attestation document or if the expected PCRs don't match the values embedded in the doc
 pub fn validate_expected_pcrs<T: PCRProvider>(
     attestation_doc: &AttestationDoc,
     expected_pcrs: &T,

--- a/attestation-doc-validation/src/attestation_doc.rs
+++ b/attestation-doc-validation/src/attestation_doc.rs
@@ -42,10 +42,10 @@ macro_rules! compare_pcrs {
 
 /// Trait to allow custom implementations of PCR-like types. This helps to make the per language bindings more idiomatic.
 pub trait PCRProvider {
-    fn pcr_0(&self) -> Option<&str>;
-    fn pcr_1(&self) -> Option<&str>;
-    fn pcr_2(&self) -> Option<&str>;
-    fn pcr_8(&self) -> Option<&str>;
+    fn pcr_0(&self) -> Option<String>;
+    fn pcr_1(&self) -> Option<String>;
+    fn pcr_2(&self) -> Option<String>;
+    fn pcr_8(&self) -> Option<String>;
 
     fn to_string(&self) -> String {
         let mut pcrs_str = String::new();
@@ -75,17 +75,17 @@ pub struct PCRs {
 }
 
 impl PCRProvider for PCRs {
-    fn pcr_0(&self) -> Option<&str> {
-        Some(self.pcr_0.as_str())
+    fn pcr_0(&self) -> Option<String> {
+        Some(self.pcr_0.clone())
     }
-    fn pcr_1(&self) -> Option<&str> {
-        Some(self.pcr_1.as_str())
+    fn pcr_1(&self) -> Option<String> {
+        Some(self.pcr_1.clone())
     }
-    fn pcr_2(&self) -> Option<&str> {
-        Some(self.pcr_2.as_str())
+    fn pcr_2(&self) -> Option<String> {
+        Some(self.pcr_2.clone())
     }
-    fn pcr_8(&self) -> Option<&str> {
-        Some(self.pcr_8.as_str())
+    fn pcr_8(&self) -> Option<String> {
+        Some(self.pcr_8.clone())
     }
 }
 

--- a/attestation-doc-validation/src/attestation_doc.rs
+++ b/attestation-doc-validation/src/attestation_doc.rs
@@ -98,8 +98,7 @@ pub fn validate_expected_pcrs<T: PCRProvider>(
     attestation_doc: &AttestationDoc,
     expected_pcrs: &T,
 ) -> AttestationDocResult<()> {
-
-    let received_pcrs = get_pcrs(attestation_doc);
+    let received_pcrs = get_pcrs(attestation_doc)?;
     let same_pcrs = expected_pcrs.eq(&received_pcrs);
     true_or_invalid(
         same_pcrs,
@@ -107,24 +106,24 @@ pub fn validate_expected_pcrs<T: PCRProvider>(
     )
 }
 
-/// Parses `PCRs` from an attestation doc
+/// Parses `PCRs` from an `AttestationDoc`
 ///
 /// # Errors
 ///
 /// Returns an error if any of the expected PCRs are missing from the attestation document
-pub fn get_pcrs(attestation_doc: &AttestationDoc) -> PCRs {
+pub fn get_pcrs(attestation_doc: &AttestationDoc) -> AttestationDocResult<PCRs> {
     let encoded_measurements = attestation_doc
         .pcrs
         .iter()
         .map(|(&index, buf)| (index, hex::encode(&buf[..])))
         .collect::<BTreeMap<_, _>>();
 
-    PCRs {
+    Ok(PCRs {
         pcr_0: extract_pcr!(encoded_measurements, 0),
         pcr_1: extract_pcr!(encoded_measurements, 1),
         pcr_2: extract_pcr!(encoded_measurements, 2),
         pcr_8: extract_pcr!(encoded_measurements, 8),
-    }
+    })
 }
 
 /// Extracts the nonce embedded in the attestation doc, encodes it to base64 and compares it to the base64 encoded nonce given

--- a/attestation-doc-validation/src/lib.rs
+++ b/attestation-doc-validation/src/lib.rs
@@ -68,6 +68,42 @@ pub fn validate_attestation_doc_in_cert(given_cert: &X509) -> error::AttestResul
     Ok(decoded_attestation_doc)
 }
 
+/// Validates an attestation doc by:
+/// - Validating the cert structure
+/// - Decoding and validating the attestation doc
+/// - Validating the signature on the attestation doc
+/// - Validating that the PCRs of the attestation doc are as expected
+///
+/// # Errors
+///
+/// Will return an error if:
+/// - The cose1 encoded attestation doc fails to parse, or its signature is invalid
+/// - The attestation document is not signed by the nitro cert chain
+/// - Any of the certificates are malformed
+///
+pub fn validate_attestation_doc(
+    attestation_doc_cose_sign_1_bytes: &[u8],
+) -> error::AttestResult<()> {
+    // Parse attestation doc from cose signature and validate structure
+    let (cose_sign_1_decoded, decoded_attestation_doc) =
+        attestation_doc::decode_attestation_document(attestation_doc_cose_sign_1_bytes)?;
+    attestation_doc::validate_attestation_document_structure(&decoded_attestation_doc)?;
+
+    // Validate that the attestation doc's signature can be tied back to the AWS Nitro CA
+    let attestation_doc_signing_cert = cert::parse_der_cert(&decoded_attestation_doc.certificate)?;
+    let received_certificates =
+        cert::parse_cert_stack_from_cabundle(decoded_attestation_doc.cabundle.as_ref())?;
+
+    cert::validate_cert_trust_chain(&attestation_doc_signing_cert, &received_certificates)?;
+
+    // Validate Cose signature over attestation doc
+    let attestation_doc_signing_cert = cert::parse_der_cert(&decoded_attestation_doc.certificate)?;
+    let attestation_doc_pub_key = cert::get_cert_public_key(&attestation_doc_signing_cert)?;
+    attestation_doc::validate_cose_signature(&attestation_doc_pub_key, &cose_sign_1_decoded)?;
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod test {
     use super::*;

--- a/attestation-doc-validation/tests/live_cert_validation.rs
+++ b/attestation-doc-validation/tests/live_cert_validation.rs
@@ -16,24 +16,24 @@ use serde::Deserialize;
 #[derive(Deserialize, Debug, PartialEq, Eq, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct TestPCRs {
-    pub pcr_0: String,
-    pub pcr_1: String,
-    pub pcr_2: String,
-    pub pcr_8: String,
+    pub pcr_0: Option<String>,
+    pub pcr_1: Option<String>,
+    pub pcr_2: Option<String>,
+    pub pcr_8: Option<String>,
 }
 
 impl PCRProvider for TestPCRs {
-    fn pcr_0(&self) -> Option<&str> {
-        Some(self.pcr_0.as_str())
+    fn pcr_0(&self) -> Option<String> {
+        self.pcr_0.clone()
     }
-    fn pcr_1(&self) -> Option<&str> {
-        Some(self.pcr_1.as_str())
+    fn pcr_1(&self) -> Option<String> {
+        self.pcr_1.clone()
     }
-    fn pcr_2(&self) -> Option<&str> {
-        Some(self.pcr_2.as_str())
+    fn pcr_2(&self) -> Option<String> {
+        self.pcr_2.clone()
     }
-    fn pcr_8(&self) -> Option<&str> {
-        Some(self.pcr_8.as_str())
+    fn pcr_8(&self) -> Option<String> {
+        self.pcr_8.clone()
     }
 }
 
@@ -102,4 +102,9 @@ fn validate_valid_attestation_doc_in_cert_incorrect_pcrs_time_sensitive() {
 #[test]
 fn validate_valid_attestation_doc_in_cert_der_encoding_time_sensitive() {
     evaluate_test_from_spec!("valid_attestation_doc_in_cert_der_encoding_time_sensitive.json");
+}
+
+#[test]
+fn valid_attestation_check_pcr8_only_time_sensitive() {
+    evaluate_test_from_spec!("valid_attestation_doc_check_pcr8_only_time_sensitive.json");
 }

--- a/attestation-doc-validation/tests/live_cert_validation.rs
+++ b/attestation-doc-validation/tests/live_cert_validation.rs
@@ -23,17 +23,17 @@ pub struct TestPCRs {
 }
 
 impl PCRProvider for TestPCRs {
-    fn pcr_0(&self) -> Option<String> {
-        self.pcr_0.clone()
+    fn pcr_0(&self) -> Option<&str> {
+        self.pcr_0.as_deref()
     }
-    fn pcr_1(&self) -> Option<String> {
-        self.pcr_1.clone()
+    fn pcr_1(&self) -> Option<&str> {
+        self.pcr_1.as_deref()
     }
-    fn pcr_2(&self) -> Option<String> {
-        self.pcr_2.clone()
+    fn pcr_2(&self) -> Option<&str> {
+        self.pcr_2.as_deref()
     }
-    fn pcr_8(&self) -> Option<String> {
-        self.pcr_8.clone()
+    fn pcr_8(&self) -> Option<&str> {
+        self.pcr_8.as_deref()
     }
 }
 

--- a/test-specs/valid_attestation_doc_check_pcr8_only_time_sensitive.json
+++ b/test-specs/valid_attestation_doc_check_pcr8_only_time_sensitive.json
@@ -1,0 +1,8 @@
+{
+    "file": "test-data/non-debug-cert-containing-attestation-document-18-1-23-der.crt",
+    "pcrs": {
+      "pcr8": "97c5395a83c0d6a04d53ff962663c714c178c24500bf97f78456ed3721d922cf3f940614da4bb90107c439bc4a1443ca"
+    },
+    "isAttestationDocValid": true,
+    "shouldPcrsMatch": true
+  }


### PR DESCRIPTION
# Why
- There's no function exposed to validate an attestation doc that isn't embedded in a cert currently
- At the moment if you use the crate it's only possible to access the PCRs as a BTreeMap. To save repeating the same code elsewhere it's easier to expose the extraction logic

# How
- Add function that parses and validates any attestation doc and returns a result
- Expose `get_prs` which returns the PCRs struct