### PR TITLE
Bump to version 0.4.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,7 +38,7 @@ dependencies = [
 
 [[package]]
 name = "attestation-doc-validation"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "aws-nitro-enclaves-cose",
  "base64 0.21.0",

--- a/attestation-doc-validation/Cargo.toml
+++ b/attestation-doc-validation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "attestation-doc-validation"
-version = "0.4.2"
+version = "0.4.3"
 edition = "2021"
 license = "Apache-2.0"
 description = "A Rust library for attesting enclaves according to the Evervault Attestation scheme. This crate is used to generate ffi bindings."


### PR DESCRIPTION
# Why
The crate needs to be released

# How
Bump version to 0.4.3
