### PR TITLE
Bump beta version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -112,7 +112,7 @@ dependencies = [
 
 [[package]]
 name = "attestation-doc-validation"
-version = "0.4.2-beta"
+version = "0.5.0-beta"
 dependencies = [
  "aes",
  "aes-gcm",

--- a/attestation-doc-validation/Cargo.toml
+++ b/attestation-doc-validation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "attestation-doc-validation"
-version = "0.4.2-beta"
+version = "0.5.0-beta"
 edition = "2021"
 license = "Apache-2.0"
 description = "A Rust library for attesting enclaves according to the Evervault Attestation scheme. This crate is used to generate ffi bindings."


### PR DESCRIPTION
# Why
We published the corresponding semver tag to the previous version, this blocks our bindings from depending on the beta (auto bumped to 0.4.2)

# How
Move beta tag to next minor version
