### PR TITLE
Update python workflow to run on tag push

### DIFF
--- a/.github/workflows/build-and-deploy-python-bindings.yml
+++ b/.github/workflows/build-and-deploy-python-bindings.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+    tags:
+      - "python/v*"
   pull_request:
   workflow_dispatch:
 


### PR DESCRIPTION
# Why
Python workflow needs to run when a tag is pushed in the form `python/v<semver>`

# How
Add event for tag push
