### PR TITLE
Broaden python support in attestation

### DIFF
--- a/python-attestation-bindings/pyproject.toml
+++ b/python-attestation-bindings/pyproject.toml
@@ -1,11 +1,11 @@
 [build-system]
-requires = ["maturin>=0.14,<0.15"]
+requires = ["maturin>=0.13,<0.15"]
 build-backend = "maturin"
 
 [project]
 name = "evervault-attestation-bindings"
-version = "0.1.0a1"
-requires-python = ">=3.7"
+version = "0.1.0a2"
+requires-python = ">=3.6"
 classifiers = [
     "Programming Language :: Rust",
     "Programming Language :: Python :: Implementation :: CPython",


### PR DESCRIPTION
# Why
Want to support the same python version range as the existing evervault python sdk

# How
Drop min version to 3.6, reduce min version of maturin to include python 3.6 support.
