### PR TITLE
Rename node project using napi and add basic readme

### DIFF
--- a/node-attestation-bindings/README.md
+++ b/node-attestation-bindings/README.md
@@ -1,0 +1,3 @@
+# Evervault Attestation Bindings
+
+This package contains node bindings to the Evervault attestation doc validation crate.

--- a/node-attestation-bindings/npm/android-arm-eabi/README.md
+++ b/node-attestation-bindings/npm/android-arm-eabi/README.md
@@ -1,3 +1,3 @@
-# `node-attestation-bindings-android-arm-eabi`
+# `evervault-attestation-bindings-android-arm-eabi`
 
-This is the **armv7-linux-androideabi** binary for `node-attestation-bindings`
+This is the **armv7-linux-androideabi** binary for `evervault-attestation-bindings`

--- a/node-attestation-bindings/npm/android-arm-eabi/package.json
+++ b/node-attestation-bindings/npm/android-arm-eabi/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "node-attestation-bindings-android-arm-eabi",
+  "name": "evervault-attestation-bindings-android-arm-eabi",
   "version": "0.0.0",
   "os": [
     "android"
@@ -7,9 +7,9 @@
   "cpu": [
     "arm"
   ],
-  "main": "node-attestation-bindings.android-arm-eabi.node",
+  "main": "evervault-attestation-bindings.android-arm-eabi.node",
   "files": [
-    "node-attestation-bindings.android-arm-eabi.node"
+    "evervault-attestation-bindings.android-arm-eabi.node"
   ],
   "license": "MIT",
   "engines": {

--- a/node-attestation-bindings/npm/android-arm64/README.md
+++ b/node-attestation-bindings/npm/android-arm64/README.md
@@ -1,3 +1,3 @@
-# `node-attestation-bindings-android-arm64`
+# `evervault-attestation-bindings-android-arm64`
 
-This is the **aarch64-linux-android** binary for `node-attestation-bindings`
+This is the **aarch64-linux-android** binary for `evervault-attestation-bindings`

--- a/node-attestation-bindings/npm/android-arm64/package.json
+++ b/node-attestation-bindings/npm/android-arm64/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "node-attestation-bindings-android-arm64",
+  "name": "evervault-attestation-bindings-android-arm64",
   "version": "0.0.0",
   "os": [
     "android"
@@ -7,9 +7,9 @@
   "cpu": [
     "arm64"
   ],
-  "main": "node-attestation-bindings.android-arm64.node",
+  "main": "evervault-attestation-bindings.android-arm64.node",
   "files": [
-    "node-attestation-bindings.android-arm64.node"
+    "evervault-attestation-bindings.android-arm64.node"
   ],
   "license": "MIT",
   "engines": {

--- a/node-attestation-bindings/npm/darwin-arm64/README.md
+++ b/node-attestation-bindings/npm/darwin-arm64/README.md
@@ -1,3 +1,3 @@
-# `node-attestation-bindings-darwin-arm64`
+# `evervault-attestation-bindings-darwin-arm64`
 
-This is the **aarch64-apple-darwin** binary for `node-attestation-bindings`
+This is the **aarch64-apple-darwin** binary for `evervault-attestation-bindings`

--- a/node-attestation-bindings/npm/darwin-arm64/package.json
+++ b/node-attestation-bindings/npm/darwin-arm64/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "node-attestation-bindings-darwin-arm64",
+  "name": "evervault-attestation-bindings-darwin-arm64",
   "version": "0.0.0",
   "os": [
     "darwin"
@@ -7,9 +7,9 @@
   "cpu": [
     "arm64"
   ],
-  "main": "node-attestation-bindings.darwin-arm64.node",
+  "main": "evervault-attestation-bindings.darwin-arm64.node",
   "files": [
-    "node-attestation-bindings.darwin-arm64.node"
+    "evervault-attestation-bindings.darwin-arm64.node"
   ],
   "license": "MIT",
   "engines": {

--- a/node-attestation-bindings/npm/darwin-universal/README.md
+++ b/node-attestation-bindings/npm/darwin-universal/README.md
@@ -1,3 +1,3 @@
-# `node-attestation-bindings-darwin-universal`
+# `evervault-attestation-bindings-darwin-universal`
 
-This is the **universal-apple-darwin** binary for `node-attestation-bindings`
+This is the **universal-apple-darwin** binary for `evervault-attestation-bindings`

--- a/node-attestation-bindings/npm/darwin-universal/package.json
+++ b/node-attestation-bindings/npm/darwin-universal/package.json
@@ -1,12 +1,12 @@
 {
-  "name": "node-attestation-bindings-darwin-universal",
+  "name": "evervault-attestation-bindings-darwin-universal",
   "version": "0.0.0",
   "os": [
     "darwin"
   ],
-  "main": "node-attestation-bindings.darwin-universal.node",
+  "main": "evervault-attestation-bindings.darwin-universal.node",
   "files": [
-    "node-attestation-bindings.darwin-universal.node"
+    "evervault-attestation-bindings.darwin-universal.node"
   ],
   "license": "MIT",
   "engines": {

--- a/node-attestation-bindings/npm/darwin-x64/README.md
+++ b/node-attestation-bindings/npm/darwin-x64/README.md
@@ -1,3 +1,3 @@
-# `node-attestation-bindings-darwin-x64`
+# `evervault-attestation-bindings-darwin-x64`
 
-This is the **x86_64-apple-darwin** binary for `node-attestation-bindings`
+This is the **x86_64-apple-darwin** binary for `evervault-attestation-bindings`

--- a/node-attestation-bindings/npm/darwin-x64/package.json
+++ b/node-attestation-bindings/npm/darwin-x64/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "node-attestation-bindings-darwin-x64",
+  "name": "evervault-attestation-bindings-darwin-x64",
   "version": "0.0.0",
   "os": [
     "darwin"
@@ -7,9 +7,9 @@
   "cpu": [
     "x64"
   ],
-  "main": "node-attestation-bindings.darwin-x64.node",
+  "main": "evervault-attestation-bindings.darwin-x64.node",
   "files": [
-    "node-attestation-bindings.darwin-x64.node"
+    "evervault-attestation-bindings.darwin-x64.node"
   ],
   "license": "MIT",
   "engines": {

--- a/node-attestation-bindings/npm/freebsd-x64/README.md
+++ b/node-attestation-bindings/npm/freebsd-x64/README.md
@@ -1,3 +1,3 @@
-# `node-attestation-bindings-freebsd-x64`
+# `evervault-attestation-bindings-freebsd-x64`
 
-This is the **x86_64-unknown-freebsd** binary for `node-attestation-bindings`
+This is the **x86_64-unknown-freebsd** binary for `evervault-attestation-bindings`

--- a/node-attestation-bindings/npm/freebsd-x64/package.json
+++ b/node-attestation-bindings/npm/freebsd-x64/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "node-attestation-bindings-freebsd-x64",
+  "name": "evervault-attestation-bindings-freebsd-x64",
   "version": "0.0.0",
   "os": [
     "freebsd"
@@ -7,9 +7,9 @@
   "cpu": [
     "x64"
   ],
-  "main": "node-attestation-bindings.freebsd-x64.node",
+  "main": "evervault-attestation-bindings.freebsd-x64.node",
   "files": [
-    "node-attestation-bindings.freebsd-x64.node"
+    "evervault-attestation-bindings.freebsd-x64.node"
   ],
   "license": "MIT",
   "engines": {

--- a/node-attestation-bindings/npm/linux-arm-gnueabihf/README.md
+++ b/node-attestation-bindings/npm/linux-arm-gnueabihf/README.md
@@ -1,3 +1,3 @@
-# `node-attestation-bindings-linux-arm-gnueabihf`
+# `evervault-attestation-bindings-linux-arm-gnueabihf`
 
-This is the **armv7-unknown-linux-gnueabihf** binary for `node-attestation-bindings`
+This is the **armv7-unknown-linux-gnueabihf** binary for `evervault-attestation-bindings`

--- a/node-attestation-bindings/npm/linux-arm-gnueabihf/package.json
+++ b/node-attestation-bindings/npm/linux-arm-gnueabihf/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "node-attestation-bindings-linux-arm-gnueabihf",
+  "name": "evervault-attestation-bindings-linux-arm-gnueabihf",
   "version": "0.0.0",
   "os": [
     "linux"
@@ -7,9 +7,9 @@
   "cpu": [
     "arm"
   ],
-  "main": "node-attestation-bindings.linux-arm-gnueabihf.node",
+  "main": "evervault-attestation-bindings.linux-arm-gnueabihf.node",
   "files": [
-    "node-attestation-bindings.linux-arm-gnueabihf.node"
+    "evervault-attestation-bindings.linux-arm-gnueabihf.node"
   ],
   "license": "MIT",
   "engines": {

--- a/node-attestation-bindings/npm/linux-arm64-gnu/README.md
+++ b/node-attestation-bindings/npm/linux-arm64-gnu/README.md
@@ -1,3 +1,3 @@
-# `node-attestation-bindings-linux-arm64-gnu`
+# `evervault-attestation-bindings-linux-arm64-gnu`
 
-This is the **aarch64-unknown-linux-gnu** binary for `node-attestation-bindings`
+This is the **aarch64-unknown-linux-gnu** binary for `evervault-attestation-bindings`

--- a/node-attestation-bindings/npm/linux-arm64-gnu/package.json
+++ b/node-attestation-bindings/npm/linux-arm64-gnu/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "node-attestation-bindings-linux-arm64-gnu",
+  "name": "evervault-attestation-bindings-linux-arm64-gnu",
   "version": "0.0.0",
   "os": [
     "linux"
@@ -7,9 +7,9 @@
   "cpu": [
     "arm64"
   ],
-  "main": "node-attestation-bindings.linux-arm64-gnu.node",
+  "main": "evervault-attestation-bindings.linux-arm64-gnu.node",
   "files": [
-    "node-attestation-bindings.linux-arm64-gnu.node"
+    "evervault-attestation-bindings.linux-arm64-gnu.node"
   ],
   "license": "MIT",
   "engines": {

--- a/node-attestation-bindings/npm/linux-arm64-musl/README.md
+++ b/node-attestation-bindings/npm/linux-arm64-musl/README.md
@@ -1,3 +1,3 @@
-# `node-attestation-bindings-linux-arm64-musl`
+# `evervault-attestation-bindings-linux-arm64-musl`
 
-This is the **aarch64-unknown-linux-musl** binary for `node-attestation-bindings`
+This is the **aarch64-unknown-linux-musl** binary for `evervault-attestation-bindings`

--- a/node-attestation-bindings/npm/linux-arm64-musl/package.json
+++ b/node-attestation-bindings/npm/linux-arm64-musl/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "node-attestation-bindings-linux-arm64-musl",
+  "name": "evervault-attestation-bindings-linux-arm64-musl",
   "version": "0.0.0",
   "os": [
     "linux"
@@ -7,9 +7,9 @@
   "cpu": [
     "arm64"
   ],
-  "main": "node-attestation-bindings.linux-arm64-musl.node",
+  "main": "evervault-attestation-bindings.linux-arm64-musl.node",
   "files": [
-    "node-attestation-bindings.linux-arm64-musl.node"
+    "evervault-attestation-bindings.linux-arm64-musl.node"
   ],
   "license": "MIT",
   "engines": {

--- a/node-attestation-bindings/npm/linux-x64-gnu/README.md
+++ b/node-attestation-bindings/npm/linux-x64-gnu/README.md
@@ -1,3 +1,3 @@
-# `node-attestation-bindings-linux-x64-gnu`
+# `evervault-attestation-bindings-linux-x64-gnu`
 
-This is the **x86_64-unknown-linux-gnu** binary for `node-attestation-bindings`
+This is the **x86_64-unknown-linux-gnu** binary for `evervault-attestation-bindings`

--- a/node-attestation-bindings/npm/linux-x64-gnu/package.json
+++ b/node-attestation-bindings/npm/linux-x64-gnu/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "node-attestation-bindings-linux-x64-gnu",
+  "name": "evervault-attestation-bindings-linux-x64-gnu",
   "version": "0.0.0",
   "os": [
     "linux"
@@ -7,9 +7,9 @@
   "cpu": [
     "x64"
   ],
-  "main": "node-attestation-bindings.linux-x64-gnu.node",
+  "main": "evervault-attestation-bindings.linux-x64-gnu.node",
   "files": [
-    "node-attestation-bindings.linux-x64-gnu.node"
+    "evervault-attestation-bindings.linux-x64-gnu.node"
   ],
   "license": "MIT",
   "engines": {

--- a/node-attestation-bindings/npm/linux-x64-musl/README.md
+++ b/node-attestation-bindings/npm/linux-x64-musl/README.md
@@ -1,3 +1,3 @@
-# `node-attestation-bindings-linux-x64-musl`
+# `evervault-attestation-bindings-linux-x64-musl`
 
-This is the **x86_64-unknown-linux-musl** binary for `node-attestation-bindings`
+This is the **x86_64-unknown-linux-musl** binary for `evervault-attestation-bindings`

--- a/node-attestation-bindings/npm/linux-x64-musl/package.json
+++ b/node-attestation-bindings/npm/linux-x64-musl/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "node-attestation-bindings-linux-x64-musl",
+  "name": "evervault-attestation-bindings-linux-x64-musl",
   "version": "0.0.0",
   "os": [
     "linux"
@@ -7,9 +7,9 @@
   "cpu": [
     "x64"
   ],
-  "main": "node-attestation-bindings.linux-x64-musl.node",
+  "main": "evervault-attestation-bindings.linux-x64-musl.node",
   "files": [
-    "node-attestation-bindings.linux-x64-musl.node"
+    "evervault-attestation-bindings.linux-x64-musl.node"
   ],
   "license": "MIT",
   "engines": {

--- a/node-attestation-bindings/npm/win32-arm64-msvc/README.md
+++ b/node-attestation-bindings/npm/win32-arm64-msvc/README.md
@@ -1,3 +1,3 @@
-# `node-attestation-bindings-win32-arm64-msvc`
+# `evervault-attestation-bindings-win32-arm64-msvc`
 
-This is the **aarch64-pc-windows-msvc** binary for `node-attestation-bindings`
+This is the **aarch64-pc-windows-msvc** binary for `evervault-attestation-bindings`

--- a/node-attestation-bindings/npm/win32-arm64-msvc/package.json
+++ b/node-attestation-bindings/npm/win32-arm64-msvc/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "node-attestation-bindings-win32-arm64-msvc",
+  "name": "evervault-attestation-bindings-win32-arm64-msvc",
   "version": "0.0.0",
   "os": [
     "win32"
@@ -7,9 +7,9 @@
   "cpu": [
     "arm64"
   ],
-  "main": "node-attestation-bindings.win32-arm64-msvc.node",
+  "main": "evervault-attestation-bindings.win32-arm64-msvc.node",
   "files": [
-    "node-attestation-bindings.win32-arm64-msvc.node"
+    "evervault-attestation-bindings.win32-arm64-msvc.node"
   ],
   "license": "MIT",
   "engines": {

--- a/node-attestation-bindings/npm/win32-ia32-msvc/README.md
+++ b/node-attestation-bindings/npm/win32-ia32-msvc/README.md
@@ -1,3 +1,3 @@
-# `node-attestation-bindings-win32-ia32-msvc`
+# `evervault-attestation-bindings-win32-ia32-msvc`
 
-This is the **i686-pc-windows-msvc** binary for `node-attestation-bindings`
+This is the **i686-pc-windows-msvc** binary for `evervault-attestation-bindings`

--- a/node-attestation-bindings/npm/win32-ia32-msvc/package.json
+++ b/node-attestation-bindings/npm/win32-ia32-msvc/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "node-attestation-bindings-win32-ia32-msvc",
+  "name": "evervault-attestation-bindings-win32-ia32-msvc",
   "version": "0.0.0",
   "os": [
     "win32"
@@ -7,9 +7,9 @@
   "cpu": [
     "ia32"
   ],
-  "main": "node-attestation-bindings.win32-ia32-msvc.node",
+  "main": "evervault-attestation-bindings.win32-ia32-msvc.node",
   "files": [
-    "node-attestation-bindings.win32-ia32-msvc.node"
+    "evervault-attestation-bindings.win32-ia32-msvc.node"
   ],
   "license": "MIT",
   "engines": {

--- a/node-attestation-bindings/npm/win32-x64-msvc/README.md
+++ b/node-attestation-bindings/npm/win32-x64-msvc/README.md
@@ -1,3 +1,3 @@
-# `node-attestation-bindings-win32-x64-msvc`
+# `evervault-attestation-bindings-win32-x64-msvc`
 
-This is the **x86_64-pc-windows-msvc** binary for `node-attestation-bindings`
+This is the **x86_64-pc-windows-msvc** binary for `evervault-attestation-bindings`

--- a/node-attestation-bindings/npm/win32-x64-msvc/package.json
+++ b/node-attestation-bindings/npm/win32-x64-msvc/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "node-attestation-bindings-win32-x64-msvc",
+  "name": "evervault-attestation-bindings-win32-x64-msvc",
   "version": "0.0.0",
   "os": [
     "win32"
@@ -7,9 +7,9 @@
   "cpu": [
     "x64"
   ],
-  "main": "node-attestation-bindings.win32-x64-msvc.node",
+  "main": "evervault-attestation-bindings.win32-x64-msvc.node",
   "files": [
-    "node-attestation-bindings.win32-x64-msvc.node"
+    "evervault-attestation-bindings.win32-x64-msvc.node"
   ],
   "license": "MIT",
   "engines": {

--- a/node-attestation-bindings/package.json
+++ b/node-attestation-bindings/package.json
@@ -41,5 +41,7 @@
     "universal": "napi universal",
     "version": "napi version"
   },
-  "packageManager": "yarn@3.3.1"
+  "packageManager": "yarn@3.3.1",
+  "repository": "https://github.com/evervault/attestation-doc-validation",
+  "description": "Node bindings to the Evervault attestation doc validation crate"
 }

--- a/node-attestation-bindings/package.json
+++ b/node-attestation-bindings/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evervault-attestation-bindings",
-  "version": "0.1.0-alpha.1",
+  "version": "0.1.0-alpha.2",
   "main": "index.js",
   "types": "index.d.ts",
   "napi": {

--- a/python-attestation-bindings/README.md
+++ b/python-attestation-bindings/README.md
@@ -1,0 +1,3 @@
+# Evervault Attestation Bindings
+
+This package contains python bindings to the Evervault attestation doc validation crate.


### PR DESCRIPTION
# Why
Node project was not renamed using NAPI, and was published without a readme.

# How
- Rename the project properly
- Add readme to both projects
- Bump node version
- Correct mislabeled node packages
