### PR TITLE
Restore freebsd support

### DIFF
--- a/.github/workflows/build-and-deploy-node-bindings.yml
+++ b/.github/workflows/build-and-deploy-node-bindings.yml
@@ -185,7 +185,7 @@ jobs:
             npm install --location=global --ignore-scripts yarn
             curl https://sh.rustup.rs -sSf --output rustup.sh
             sh rustup.sh -y --profile minimal --default-toolchain stable
-            source "/usr/local/cargo/env"
+            export PATH="/usr/local/cargo/bin:$PATH"
             echo "~~~~ rustc --version ~~~~"
             rustc --version
             echo "~~~~ node -v ~~~~"
@@ -193,7 +193,8 @@ jobs:
             echo "~~~~ yarn --version ~~~~"
             yarn --version
           run: |
-            source "/usr/local/cargo/env"
+            export PATH="/usr/local/cargo/bin:$PATH"
+            cargo --version
             pwd
             ls -lah
             whoami
@@ -201,10 +202,10 @@ jobs:
             freebsd-version
             cd node-attestation-bindings
             ls
+            cargo metadata --format-version 1 --manifest-path "/Users/runner/work/attestation-doc-validation/attestation-doc-validation/node-attestation-bindings/Cargo.toml"
             yarn install
             yarn build
             ls
-            pwd
             strip -x *.node
             yarn test
             rm -rf node_modules

--- a/.github/workflows/build-and-deploy-node-bindings.yml
+++ b/.github/workflows/build-and-deploy-node-bindings.yml
@@ -185,7 +185,7 @@ jobs:
             npm install --location=global --ignore-scripts yarn
             curl https://sh.rustup.rs -sSf --output rustup.sh
             sh rustup.sh -y --profile minimal --default-toolchain stable
-            export PATH="/usr/local/cargo/bin:$PATH"
+            source "/usr/local/cargo/env"
             echo "~~~~ rustc --version ~~~~"
             rustc --version
             echo "~~~~ node -v ~~~~"
@@ -193,7 +193,7 @@ jobs:
             echo "~~~~ yarn --version ~~~~"
             yarn --version
           run: |
-            export PATH="/usr/local/cargo/bin:$PATH"
+            source "/usr/local/cargo/env"
             pwd
             ls -lah
             whoami
@@ -204,7 +204,7 @@ jobs:
             yarn install
             yarn build
             ls
-            cwd
+            pwd
             strip -x *.node
             yarn test
             rm -rf node_modules

--- a/.github/workflows/build-and-deploy-node-bindings.yml
+++ b/.github/workflows/build-and-deploy-node-bindings.yml
@@ -162,60 +162,60 @@ jobs:
           name: bindings-${{ matrix.settings.target }}
           path: ./${{ env.SUBDIRECTORY }}/${{ env.APP_NAME }}.*.node
           if-no-files-found: error
-  # build-freebsd:
-  #   runs-on: macos-12
-  #   name: Build FreeBSD
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - name: Build
-  #       id: build
-  #       uses: vmactions/freebsd-vm@v0
-  #       env:
-  #         DEBUG: napi:*
-  #         RUSTUP_HOME: /usr/local/rustup
-  #         CARGO_HOME: /usr/local/cargo
-  #         RUSTUP_IO_THREADS: 1
-  #       with:
-  #         envs: DEBUG RUSTUP_HOME CARGO_HOME RUSTUP_IO_THREADS
-  #         usesh: true
-  #         mem: 3000
-  #         prepare: |
-  #           pkg install -y -f curl node libnghttp2
-  #           curl -qL https://www.npmjs.com/install.sh | sh
-  #           npm install --location=global --ignore-scripts yarn
-  #           curl https://sh.rustup.rs -sSf --output rustup.sh
-  #           sh rustup.sh -y --profile minimal --default-toolchain stable
-  #           export PATH="/usr/local/cargo/bin:$PATH"
-  #           echo "~~~~ rustc --version ~~~~"
-  #           rustc --version
-  #           echo "~~~~ node -v ~~~~"
-  #           node -v
-  #           echo "~~~~ yarn --version ~~~~"
-  #           yarn --version
-  #         run: |
-  #           export PATH="/usr/local/cargo/bin:$PATH"
-  #           pwd
-  #           ls -lah
-  #           whoami
-  #           env
-  #           freebsd-version
-  #           cd node-attestation-bindings
-  #           ls
-  #           yarn install
-  #           yarn build
-  #           ls
-  #           cwd
-  #           strip -x *.node
-  #           yarn test
-  #           rm -rf node_modules
-  #           rm -rf target
-  #           rm -rf .yarn/cache
-  #     - name: Upload artifact
-  #       uses: actions/upload-artifact@v3
-  #       with:
-  #         name: bindings-freebsd
-  #         path: ./${{ env.SUBDIRECTORY }}/${{ env.APP_NAME }}.*.node
-  #         if-no-files-found: error
+  build-freebsd:
+    runs-on: macos-12
+    name: Build FreeBSD
+    steps:
+      - uses: actions/checkout@v3
+      - name: Build
+        id: build
+        uses: vmactions/freebsd-vm@v0
+        env:
+          DEBUG: napi:*
+          RUSTUP_HOME: /usr/local/rustup
+          CARGO_HOME: /usr/local/cargo
+          RUSTUP_IO_THREADS: 1
+        with:
+          envs: DEBUG RUSTUP_HOME CARGO_HOME RUSTUP_IO_THREADS
+          usesh: true
+          mem: 3000
+          prepare: |
+            pkg install -y -f curl node libnghttp2
+            curl -qL https://www.npmjs.com/install.sh | sh
+            npm install --location=global --ignore-scripts yarn
+            curl https://sh.rustup.rs -sSf --output rustup.sh
+            sh rustup.sh -y --profile minimal --default-toolchain stable
+            export PATH="/usr/local/cargo/bin:$PATH"
+            echo "~~~~ rustc --version ~~~~"
+            rustc --version
+            echo "~~~~ node -v ~~~~"
+            node -v
+            echo "~~~~ yarn --version ~~~~"
+            yarn --version
+          run: |
+            export PATH="/usr/local/cargo/bin:$PATH"
+            pwd
+            ls -lah
+            whoami
+            env
+            freebsd-version
+            cd node-attestation-bindings
+            ls
+            yarn install
+            yarn build
+            ls
+            cwd
+            strip -x *.node
+            yarn test
+            rm -rf node_modules
+            rm -rf target
+            rm -rf .yarn/cache
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: bindings-freebsd
+          path: ./${{ env.SUBDIRECTORY }}/${{ env.APP_NAME }}.*.node
+          if-no-files-found: error
 
   # These windows tests will fail — windows does not support libfaketime
   # test-macOS-windows-binding:


### PR DESCRIPTION
# Why
Freebsd support is required to use the client in Github Actions

# How
—
