### PR TITLE
Improve attestation doc validation errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,7 +38,7 @@ dependencies = [
 
 [[package]]
 name = "attestation-doc-validation"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "aws-nitro-enclaves-cose",
  "base64 0.21.0",

--- a/attestation-doc-validation/Cargo.toml
+++ b/attestation-doc-validation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "attestation-doc-validation"
-version = "0.4.3"
+version = "0.4.4"
 edition = "2021"
 license = "Apache-2.0"
 description = "A Rust library for attesting enclaves according to the Evervault Attestation scheme. This crate is used to generate ffi bindings."
@@ -20,7 +20,7 @@ thiserror = "1.0"
 serde_cbor = "0.11"
 hex = "0.4.3"
 base64 = "0.21"
-serde_bytes = "0.11"
+serde_bytes = "0.11"#[cfg(not(feature = "tls_server"))]
 serde = { version = "1.0", features = ["derive"] }
 serde_with = "2.2"
 

--- a/attestation-doc-validation/src/error.rs
+++ b/attestation-doc-validation/src/error.rs
@@ -51,6 +51,20 @@ where
         expected: String,
         received: Option<String>,
     },
+    #[error("The module id was missing from the attestation doc")]
+    MissingModuleId,
+    #[error("The digest in the attestation was not SHA384")]
+    DigestAlgorithmInvalid,
+    #[error("The PCRs in the attestation doc were invalid")]
+    InvalidPCRs,
+    #[error("The CA bundle length in the attestation doc was invalid")]
+    InvalidCABundle,
+    #[error("The public key length in the attestation doc was invalid")]
+    InvalidPublicKey,
+    #[error("The nonce length in the attestation doc was invalid")]
+    InvalidNonce,
+    #[error("The user data length in the attestation doc was invalid")]
+    InvalidUserData,
 }
 
 /// Wrapping type to record the specific error that occurred while validating the TLS Cert.


### PR DESCRIPTION
# Why
The errors for invalid attestation docs are very vague as they're currently in a single boolean

# How
Return more descriptive error