### PR TITLE
Fix version assertion in publish actions

### DIFF
--- a/.github/workflows/build-and-deploy-node-bindings.yml
+++ b/.github/workflows/build-and-deploy-node-bindings.yml
@@ -411,18 +411,15 @@ jobs:
         id: get-version
         run: |
           echo "using version tag ${GITHUB_REF:16}"
-          echo "name=version::${GITHUB_REF:16}\n" >> $GITHUB_OUTPUT
       - uses: actions/checkout@v3
-      # - name: Assert versions match
-      #   run: |
-      #     PACKAGE_VERSION=$(cat ./node-attestation-bindings/package.json | jq .version | tr -d '"')
-      #     if [ "$PACKAGE_VERSION" != "$TAG_VERSION" ]; then
-      #       echo "Version in tag does not match package.json"
-      #       echo "Expected $PACKAGE_VERSION, Found $TAG_VERSION"
-      #       exit 1
-      #     fi
-      #   env:
-      #     TAG_VERSION: ${{ steps.get-version.outputs.version }}
+      - name: Assert versions match
+        run: |
+          PACKAGE_VERSION=$(cat ./node-attestation-bindings/package.json | jq .version | tr -d '"')
+          if [ "$PACKAGE_VERSION" != "${GITHUB_REF:16}" ]; then
+            echo "Version in tag does not match package.json"
+            echo "Expected $PACKAGE_VERSION, Found ${GITHUB_REF:16}"
+            exit 1
+          fi
       - name: Setup node
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/build-and-deploy-python-bindings.yml
+++ b/.github/workflows/build-and-deploy-python-bindings.yml
@@ -66,19 +66,16 @@ jobs:
         id: get-version
         run: |
           echo "using version tag ${GITHUB_REF:16}"
-          echo "name=version::${GITHUB_REF:18}\n" >> $GITHUB_OUTPUT
       - uses: actions/checkout@v3
-      # - name: Assert versions match
-      #   run: |
-      #     cd python-attestation-bindings
-      #     PACKAGE_VERSION=$(cat pyproject.toml | grep "version" | xargs -n1 -d ' ' | tail -n1)
-      #     if [ "$PACKAGE_VERSION" != "$TAG_VERSION" ]; then
-      #       echo "Version in tag does not match package.json"
-      #       echo "Expected $PACKAGE_VERSION, Found $TAG_VERSION"
-      #       exit 1
-      #     fi
-      #   env:
-      #     TAG_VERSION: ${{ steps.get-version.outputs.version }}
+      - name: Assert versions match
+        run: |
+          cd python-attestation-bindings
+          PACKAGE_VERSION=$(cat pyproject.toml | grep "version" | xargs -n1 -d ' ' | tail -n1)
+          if [ "$PACKAGE_VERSION" != "${GITHUB_REF:16}" ]; then
+            echo "Version in tag does not match package.json"
+            echo "Expected $PACKAGE_VERSION, Found ${GITHUB_REF:16}"
+            exit 1
+          fi
       - name: Guarantee wheels dir exists
         run: mkdir python-attestation-bindings/wheels
       - uses: actions/download-artifact@v3

--- a/.github/workflows/publish-rust-crate.yml
+++ b/.github/workflows/publish-rust-crate.yml
@@ -15,7 +15,6 @@ jobs:
         id: get-version
         run: |
           echo "using version tag ${GITHUB_REF:16}"
-          echo "version=${GITHUB_REF:16}\n" >> $GITHUB_OUTPUT
   assert-matching-version:
     runs-on: ubuntu-latest
     needs: [get-version]
@@ -30,13 +29,11 @@ jobs:
         id: get-cargo-version
         run: |
           CARGO_VERSION=$(cargo metadata --no-deps --format-version 1 | jq '.packages[] | select( .name == "attestation-doc-validation" ) | .version' | tr -d '"')
-          if [ "$CARGO_VERSION" != "${{ env.TAG_VERSION }}" ]; then
+          if [ "$CARGO_VERSION" != "${GITHUB_REF:16}" ]; then
             echo "Version in tag does not match cargo.toml"
-            echo "Expected $CARGO_VERSION, Found ${{ env.TAG_VERSION }}"
+            echo "Expected $CARGO_VERSION, Found ${GITHUB_REF:16}"
             exit 1
           fi
-        env:
-          TAG_VERSION: ${{ needs.get-version.outputs.version }}
   # Before publishing, validate that all tests pass
   run-ci-checks:
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Why
Version check is failing, as there's an extra `\n`

# How
Don't parse the version into a github variable first. Try to just use `${GITHUB_REF:16}` directly
