### PR TITLE
Update bindings to take in multiple sets of PCRs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,32 +96,6 @@ dependencies = [
 
 [[package]]
 name = "attestation-doc-validation"
-version = "0.5.0-beta"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33c1d46e832e4a525c36b005cda831994d00cabf5842ff4c07078a0f8a2b9398"
-dependencies = [
- "aes",
- "aes-gcm",
- "aws-nitro-enclaves-cose",
- "base64 0.21.0",
- "der",
- "ecdsa",
- "hex",
- "p256",
- "p384",
- "rand",
- "serde",
- "serde_bytes",
- "serde_cbor",
- "serde_with 2.2.0",
- "sha2",
- "thiserror",
- "webpki",
- "x509-parser",
-]
-
-[[package]]
-name = "attestation-doc-validation"
 version = "0.6.0"
 dependencies = [
  "aes",
@@ -140,6 +114,32 @@ dependencies = [
  "serde_bytes",
  "serde_cbor",
  "serde_json",
+ "serde_with 2.2.0",
+ "sha2",
+ "thiserror",
+ "webpki",
+ "x509-parser",
+]
+
+[[package]]
+name = "attestation-doc-validation"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07f41a9d17e59a15b9208f55985f3f0eea9830695cd6280acce32e9619ded698"
+dependencies = [
+ "aes",
+ "aes-gcm",
+ "aws-nitro-enclaves-cose",
+ "base64 0.21.0",
+ "der",
+ "ecdsa",
+ "hex",
+ "p256",
+ "p384",
+ "rand",
+ "serde",
+ "serde_bytes",
+ "serde_cbor",
  "serde_with 2.2.0",
  "sha2",
  "thiserror",
@@ -802,7 +802,7 @@ dependencies = [
 name = "node-attestation-bindings"
 version = "0.0.0"
 dependencies = [
- "attestation-doc-validation 0.5.0-beta",
+ "attestation-doc-validation 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "napi",
  "napi-build",
  "napi-derive",
@@ -1068,7 +1068,7 @@ dependencies = [
 name = "python-attestation-bindings"
 version = "0.0.0"
 dependencies = [
- "attestation-doc-validation 0.5.0-beta",
+ "attestation-doc-validation 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pyo3",
 ]
 

--- a/node-attestation-bindings/Cargo.toml
+++ b/node-attestation-bindings/Cargo.toml
@@ -14,7 +14,7 @@ crate-type = ["cdylib"]
 # Default enable napi4 feature, see https://nodejs.org/api/n-api.html#node-api-version-matrix
 napi = { version = "2.10.6", default-features = false, features = ["napi4"] }
 napi-derive = "2.9.4"
-attestation-doc-validation = "0.5.0-beta"
+attestation-doc-validation = "0.6.0"
 
 [build-dependencies]
 napi-build = "2.0.1"

--- a/node-attestation-bindings/__test__/index.spec.mjs
+++ b/node-attestation-bindings/__test__/index.spec.mjs
@@ -27,7 +27,7 @@ for (let testSpec of directory) {
       JSON.parse(specText);
 
     const inputFile = resolveCert(file);
-    const isConnectionValid = attestConnection(inputFile, pcrs);
+    const isConnectionValid = attestConnection(inputFile, [pcrs]);
     t.deepEqual(isConnectionValid, isAttestationDocValid && shouldPcrsMatch);
   });
 }

--- a/node-attestation-bindings/index.d.ts
+++ b/node-attestation-bindings/index.d.ts
@@ -10,4 +10,4 @@ export interface NodePcRs {
   pcr2?: string
   pcr8?: string
 }
-export function attestConnection(cert: Buffer, expectedPcrs?: NodePcRs | undefined | null): boolean
+export function attestConnection(cert: Buffer, expectedPcrsList: Array<NodePcRs>): boolean

--- a/node-attestation-bindings/package.json
+++ b/node-attestation-bindings/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evervault-attestation-bindings",
-  "version": "0.1.0-alpha.3",
+  "version": "0.2.0",
   "main": "index.js",
   "types": "index.d.ts",
   "napi": {

--- a/python-attestation-bindings/Cargo.toml
+++ b/python-attestation-bindings/Cargo.toml
@@ -13,5 +13,5 @@ name = "evervault_attestation_bindings"
 crate-type = ["cdylib"]
 
 [dependencies]
-attestation-doc-validation = { version = "0.5.0-beta" }
+attestation-doc-validation = { version = "0.6.0" }
 pyo3 = { version = "0.18", features = ["extension-module"] }

--- a/python-attestation-bindings/pyproject.toml
+++ b/python-attestation-bindings/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "evervault_attestation_bindings"
-version = "0.1.0a5"
+version = "0.2.0"
 requires-python = ">=3.6"
 classifiers = [
     "Programming Language :: Rust",


### PR DESCRIPTION
# Why
Our SDKs will have the ability to try multiple sets of PCRs, to allow for rollover of certs/containers

# How
* Take in a list of  PCR objects instead of a single one. To validate a single set of PCRs, you just pass in a single-element list
    * If the list of PCRs to check is empty, return true
    * If any of the PCRs in the list match, return true
    * If they all fail, return the last error
* Bump versions to non-beta
