### PR TITLE
Fix python version parsing

### DIFF
--- a/.github/workflows/build-and-deploy-python-bindings.yml
+++ b/.github/workflows/build-and-deploy-python-bindings.yml
@@ -65,15 +65,15 @@ jobs:
       - name: Get version from tag
         id: get-version
         run: |
-          echo "using version tag ${GITHUB_REF:16}"
+          echo "using version tag ${GITHUB_REF:18}"
       - uses: actions/checkout@v3
       - name: Assert versions match
         run: |
           cd python-attestation-bindings
           PACKAGE_VERSION=$(cat pyproject.toml | grep "version" | xargs -n1 -d ' ' | tail -n1)
-          if [ "$PACKAGE_VERSION" != "${GITHUB_REF:16}" ]; then
+          if [ "$PACKAGE_VERSION" != "${GITHUB_REF:18}" ]; then
             echo "Version in tag does not match package.json"
-            echo "Expected $PACKAGE_VERSION, Found ${GITHUB_REF:16}"
+            echo "Expected $PACKAGE_VERSION, Found ${GITHUB_REF:18}"
             exit 1
           fi
       - name: Guarantee wheels dir exists


### PR DESCRIPTION
# Why
Using the wrong character offset when parsing the version out of the tag. This is blocking Python bindings deployments

# How
Use correct character offset when parsing python version
