### PR TITLE
markd/add v2 attesation node api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -140,32 +140,6 @@ dependencies = [
 
 [[package]]
 name = "attestation-doc-validation"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "264310c1d02b13567aece4f17c1ec3451fffb8f058bd900c6ae958392597c6fc"
-dependencies = [
- "aes",
- "aes-gcm",
- "aws-nitro-enclaves-cose",
- "base64 0.21.3",
- "der",
- "ecdsa",
- "hex",
- "p256",
- "p384",
- "rand",
- "serde",
- "serde_bytes",
- "serde_cbor",
- "serde_with 2.3.3",
- "sha2",
- "thiserror",
- "webpki",
- "x509-parser",
-]
-
-[[package]]
-name = "attestation-doc-validation"
 version = "0.6.2"
 dependencies = [
  "aes",
@@ -186,6 +160,34 @@ dependencies = [
  "serde_bytes",
  "serde_cbor",
  "serde_json",
+ "serde_with 2.3.3",
+ "sha2",
+ "thiserror",
+ "webpki",
+ "x509-parser",
+]
+
+[[package]]
+name = "attestation-doc-validation"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "973b4b984443afd77621463bcf75539cd984e015367b7c588efcdf4af6f39852"
+dependencies = [
+ "aes",
+ "aes-gcm",
+ "aws-nitro-enclaves-cose",
+ "base64 0.21.3",
+ "bincode",
+ "chrono",
+ "der",
+ "ecdsa",
+ "hex",
+ "p256",
+ "p384",
+ "rand",
+ "serde",
+ "serde_bytes",
+ "serde_cbor",
  "serde_with 2.3.3",
  "sha2",
  "thiserror",
@@ -773,7 +775,7 @@ dependencies = [
 name = "kotlin-attestation-bindings"
 version = "0.1.0"
 dependencies = [
- "attestation-doc-validation 0.6.1",
+ "attestation-doc-validation 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "uniffi",
 ]
 
@@ -913,7 +915,7 @@ dependencies = [
 name = "node-attestation-bindings"
 version = "0.0.0"
 dependencies = [
- "attestation-doc-validation 0.6.1",
+ "attestation-doc-validation 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "napi",
  "napi-build",
  "napi-derive",
@@ -1191,7 +1193,7 @@ dependencies = [
 name = "python-attestation-bindings"
 version = "0.0.0"
 dependencies = [
- "attestation-doc-validation 0.6.1",
+ "attestation-doc-validation 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "pyo3",
 ]
 

--- a/kotlin-attestation-bindings/Cargo.toml
+++ b/kotlin-attestation-bindings/Cargo.toml
@@ -8,7 +8,7 @@ name = "bindings"
 crate-type = ["cdylib"]
 
 [dependencies]
-attestation-doc-validation = "0.6.1"
+attestation-doc-validation = "0.6.2"
 uniffi = { version = "0.24.1" }
 
 [build-dependencies]

--- a/node-attestation-bindings/Cargo.toml
+++ b/node-attestation-bindings/Cargo.toml
@@ -14,7 +14,7 @@ crate-type = ["cdylib"]
 # Default enable napi4 feature, see https://nodejs.org/api/n-api.html#node-api-version-matrix
 napi = { version = "2.10.6", default-features = false, features = ["napi4"] }
 napi-derive = "2.9.4"
-attestation-doc-validation = "0.6.1"
+attestation-doc-validation = "0.6.2"
 
 [build-dependencies]
 napi-build = "2.0.1"

--- a/python-attestation-bindings/Cargo.toml
+++ b/python-attestation-bindings/Cargo.toml
@@ -13,5 +13,5 @@ name = "evervault_attestation_bindings"
 crate-type = ["cdylib"]
 
 [dependencies]
-attestation-doc-validation = { version = "0.6.1" }
+attestation-doc-validation = { version = "0.6.2" }
 pyo3 = { version = "0.18", features = ["extension-module"] }


### PR DESCRIPTION
# Why
Implements #59 

# How
Add new node methods, need to release new version of `attesation-doc-validation` before this will work
