### PR TITLE
Bump node bindings minor version

### DIFF
--- a/node-attestation-bindings/package.json
+++ b/node-attestation-bindings/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evervault-attestation-bindings",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "main": "index.js",
   "types": "index.d.ts",
   "napi": {


### PR DESCRIPTION
# Why
Bump node binding version for next release

# How
Bump to 0.3.0
