### PR TITLE
[SPE-855] Add new swift attest_cage method for attesting against trusted cert 

### DIFF
--- a/swift-attestation-bindings/ios/AttestationBindingsRustFFI.h
+++ b/swift-attestation-bindings/ios/AttestationBindingsRustFFI.h
@@ -10,3 +10,6 @@ struct PCRs {
 };
 
 bool attest_connection(const uint8_t* cert, size_t cert_len, const struct PCRs* expected_pcrs_list, size_t expected_pcrs_len);
+
+bool attest_cage(const uint8_t* cert, size_t cert_len, const struct PCRs* expected_pcrs_list, size_t expected_pcrs_len, const uint8_t* attestation_doc, size_t attestation_doc_len);
+

--- a/swift-attestation-bindings/src/lib.rs
+++ b/swift-attestation-bindings/src/lib.rs
@@ -1,5 +1,5 @@
-use attestation_doc_validation::attestation_doc::{validate_expected_pcrs, PCRProvider};
-use attestation_doc_validation::{parse_cert, validate_attestation_doc_in_cert};
+use attestation_doc_validation::attestation_doc::{validate_expected_pcrs, PCRProvider, self};
+use attestation_doc_validation::{parse_cert, validate_attestation_doc_in_cert, validate_attestation_doc_against_cert};
 use std::ffi::CStr;
 use std::os::raw::c_char;
 use std::os::raw::c_int;
@@ -57,7 +57,7 @@ pub extern "C" fn attest_connection(
     cert: *const u8,
     cert_len: usize,
     expected_pcrs_list: *const PCRs,
-    expected_pcrs_len: usize,
+    expected_pcrs_len: usize
 ) -> bool {
     assert!(!cert.is_null());
 
@@ -79,6 +79,55 @@ pub extern "C" fn attest_connection(
             eprintln!("An error occurred while validating the connection to this Cage: {e}");
             return false;
         }
+    };
+
+    let mut result = Ok(true);
+    for expected_pcrs in expected_pcrs_slice {
+        match validate_expected_pcrs(&validated_attestation_doc, &expected_pcrs) {
+            Ok(_) => return true,
+            Err(err) => result = Err(err),
+        }
+    }
+
+    match result {
+        Ok(_) => true,
+        Err(e) => {
+            eprintln!("Failed to validate that PCRs are as expected: {e}");
+            false
+        }
+    }
+}
+
+pub extern "C" fn attest_cage(
+    cert: *const u8,
+    cert_len: usize,
+    expected_pcrs_list: *const PCRs,
+    expected_pcrs_len: usize,
+    attestation_doc: *const u8,
+    attestation_doc_len: usize,
+) -> bool {
+    assert!(!cert.is_null());
+    assert!(!attestation_doc.is_null());
+
+    let cert_slice = unsafe { std::slice::from_raw_parts(cert, cert_len) };
+    let expected_pcrs_slice =
+        unsafe { std::slice::from_raw_parts(expected_pcrs_list, expected_pcrs_len) };
+    let attestation_doc_slice = unsafe { std::slice::from_raw_parts(attestation_doc, attestation_doc_len) };
+
+    let parsed_cert = match parse_cert(cert_slice) {
+        Ok(parsed_cert) => parsed_cert,
+        Err(e) => {
+            eprintln!("Failed to parse provided cert: {e}");
+            return false;
+        }
+    };
+
+    let validated_attestation_doc = match validate_attestation_doc_against_cert(&parsed_cert, &attestation_doc_slice) {
+        Ok(attestation_doc) => attestation_doc,
+        Err(err) => {
+            eprintln!("An error occurred while validating the connection to this Cage: {err}");
+            return false;
+        },
     };
 
     let mut result = Ok(true);


### PR DESCRIPTION
# Why
Cages have a trusted cert now but the attestation doc isn't embedded in the cert. This mean the AD has to be pulled from the cage and passed into the attestation function.

# How
Added `attest_cage()` which takes in the cert, the expected_pcrs and the attestation document (already pulled from the cage). Then use the `validate_attestation_doc_against_cert` method from the rust bindings to validate that the public key of the cert matches the public key embedded in the attestation document given to the function.