### PR TITLE
Raise error on invalid pcrs

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,11 @@ pcrs = python_attestation_bindings.PCRs("<pcr0>","<pcr1>","<pcr2>","<pcr8>")
 python_attestation_bindings.attest_connection(<cert>, pcrs)
 ```
 
+To run tests 
+```sh
+maturin develop && pytest
+```
+
 ## Makefile
 
 Each project has some useful tasks defined in their `Makefile.toml`:

--- a/python-attestation-bindings/pyproject.toml
+++ b/python-attestation-bindings/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "evervault_attestation_bindings"
-version = "0.3.0"
+version = "0.3.1"
 requires-python = ">=3.6"
 classifiers = [
     "Programming Language :: Rust",

--- a/python-attestation-bindings/src/lib.rs
+++ b/python-attestation-bindings/src/lib.rs
@@ -134,17 +134,10 @@ pub fn attest_cage(
     for expected_pcrs in expected_pcrs_list {
         match validate_expected_pcrs(&validated_attestation_doc, &expected_pcrs) {
             Ok(_) => return Ok(true),
-            Err(err) => result = Err(err),
+            Err(err) => result = Err(PyValueError::new_err(format!("{err}"))),
         }
     }
-
-    match result {
-        Ok(_) => Ok(true),
-        Err(e) => {
-            eprintln!("Failed to validate that PCRs are as expected: {e}");
-            Ok(false)
-        }
-    }
+    result
 }
 
 /// A small python module offering bindings to the rust attestation doc validation project

--- a/python-attestation-bindings/tests/test_attestation.py
+++ b/python-attestation-bindings/tests/test_attestation.py
@@ -29,6 +29,5 @@ def test_attest_incorrect_pcrs():
         "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
         "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000050000000",
     )
-    result = evervault_attestation_bindings.attest_cage(cert, [pcrs], attestation_doc)
-
-    assert result == False    
+    with pytest.raises(ValueError, match="The PCRs found were different to the expected values"):
+        evervault_attestation_bindings.attest_cage(cert, [pcrs], attestation_doc)  


### PR DESCRIPTION
# Why
Its more helpful to see the error then return a log and bool

# How
Raise error instead of false
