### PR TITLE
Explicitly build for arm linux targets

### DIFF
--- a/.github/workflows/build-and-deploy-python-bindings.yml
+++ b/.github/workflows/build-and-deploy-python-bindings.yml
@@ -13,7 +13,6 @@ jobs:
   linux:
     runs-on: ubuntu-latest
     steps:
-      - uses: docker/setup-qemu-action@v1
       - uses: actions/checkout@v3
       - uses: PyO3/maturin-action@v1
         with:
@@ -21,6 +20,28 @@ jobs:
           command: build
           args: --release --sdist -o dist --find-interpreter
           working-directory: python-attestation-bindings
+      - uses: docker/setup-qemu-action@v1  
+      - uses: PyO3/maturin-action@v1
+        with:
+          manylinux: auto
+          command: build
+          target: armv7-unknown-linux-gnueabihf
+          args: --release --sdist -o dist --find-interpreter
+          working-directory: python-attestation-bindings
+      - uses: PyO3/maturin-action@v1
+        with:
+          manylinux: auto
+          command: build
+          target: aarch64-unknown-linux-gnu
+          args: --release --sdist -o dist --find-interpreter
+          working-directory: python-attestation-bindings 
+      - uses: PyO3/maturin-action@v1
+        with:
+          manylinux: auto
+          command: build
+          target: aarch64-unknown-linux-musl
+          args: --release --sdist -o dist --find-interpreter
+          working-directory: python-attestation-bindings      
       - name: Upload wheels
         uses: actions/upload-artifact@v3
         with:

--- a/python-attestation-bindings/pyproject.toml
+++ b/python-attestation-bindings/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["maturin>=0.13,<0.15"]
+requires = ["maturin>=1.0,<2.0"]
 build-backend = "maturin"
 
 [project]

--- a/python-attestation-bindings/pyproject.toml
+++ b/python-attestation-bindings/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "evervault_attestation_bindings"
-version = "0.3.2"
+version = "0.3.3"
 requires-python = ">=3.6"
 classifiers = [
     "Programming Language :: Rust",


### PR DESCRIPTION
# Why
Bindings are missing for python builds on arm linux. The default behaviour was just building for x86 so we weren't releasing wheels for every os & arch

# How
Add steps that explicitly target builds for arm linux targets
