### PR TITLE
Add missing updates to swift

### DIFF
--- a/swift-attestation-bindings/build-xcframework.sh
+++ b/swift-attestation-bindings/build-xcframework.sh
@@ -79,16 +79,20 @@ cargo_build () {
 
 set -euvx
 
+# Set up the rust environment.
+rustup install nightly
+rustup default nightly
+rustup target add x86_64-apple-ios
+rustup target add aarch64-apple-ios-sim
+rustup target add aarch64-apple-ios
+
 # Intel iOS simulator
-CFLAGS_x86_64_apple_ios="-target x86_64-apple-ios" \
-  cargo_build x86_64-apple-ios
+CFLAGS_x86_64_apple_ios="-target x86_64-apple-ios" cargo +nightly build --target x86_64-apple-ios --release
 
 # Hardware iOS targets
-cargo_build aarch64-apple-ios
+cargo +nightly build --target aarch64-apple-ios --release
 
-# M1 iOS simulator.
-CFLAGS_aarch64_apple_ios_sim="-target aarch64-apple-ios-sim" \
-  cargo_build aarch64-apple-ios-sim
+cargo +nightly build -Z build-std --target aarch64-apple-ios-sim --release
 
 # TODO: would it be useful to also include desktop builds here?
 # It might make it possible to run the Swift tests via `swift test`

--- a/swift-attestation-bindings/src/lib.rs
+++ b/swift-attestation-bindings/src/lib.rs
@@ -96,6 +96,7 @@ pub extern "C" fn attest_connection(
     }
 }
 
+#[no_mangle]
 pub extern "C" fn attest_cage(
     cert: *const u8,
     cert_len: usize,


### PR DESCRIPTION
# Why
As swift is built locally and then uploaded to a release, I had some updates locally which hadn't been committed.

# How
Updated swift bindings to have `no_mangle` and updated the build xc_framework script to allow non rosetta simulator 
