### PR TITLE
feat: make PCRs optional

### DIFF
--- a/kotlin-attestation-bindings/src/bindings.udl
+++ b/kotlin-attestation-bindings/src/bindings.udl
@@ -4,8 +4,8 @@ namespace bindings {
 };
 
 dictionary PCRs {
-  string pcr0;
-  string pcr1;
-  string pcr2;
-  string pcr8;
+  string? pcr0;
+  string? pcr1;
+  string? pcr2;
+  string? pcr8;
 };

--- a/kotlin-attestation-bindings/src/lib.rs
+++ b/kotlin-attestation-bindings/src/lib.rs
@@ -3,27 +3,27 @@ use attestation_doc_validation::attestation_doc::{validate_expected_pcrs, PCRPro
 use attestation_doc_validation::{parse_cert, validate_attestation_doc_in_cert, validate_attestation_doc_against_cert};
 
 pub struct PCRs {
-    pcr0: String,
-    pcr1: String,
-    pcr2: String,
-    pcr8: String,
+    pcr0: Option<String>,
+    pcr1: Option<String>,
+    pcr2: Option<String>,
+    pcr8: Option<String>,
 }
 
 impl PCRProvider for PCRs {
     fn pcr_0(&self) -> Option<&str> {
-        Some(&self.pcr0)
+        self.pcr0.as_deref()
     }
 
     fn pcr_1(&self) -> Option<&str> {
-        Some(&self.pcr1)
+        self.pcr1.as_deref()
     }
 
     fn pcr_2(&self) -> Option<&str> {
-        Some(&self.pcr2)
+        self.pcr2.as_deref()
     }
 
     fn pcr_8(&self) -> Option<&str> {
-        Some(&self.pcr8)
+        self.pcr8.as_deref()
     }
 }
 

--- a/kotlin-attestation-bindings/src/uniffi/bindings/bindings.kt
+++ b/kotlin-attestation-bindings/src/uniffi/bindings/bindings.kt
@@ -3,7 +3,7 @@
 
 @file:Suppress("NAME_SHADOWING")
 
-package uniffi.bindings
+package uniffi.bindings;
 
 // Common helper code.
 //
@@ -17,11 +17,12 @@ package uniffi.bindings
 // compile the Rust component. The easiest way to ensure this is to bundle the Kotlin
 // helpers directly inline like we're doing here.
 
-import com.sun.jna.IntegerType
 import com.sun.jna.Library
+import com.sun.jna.IntegerType
 import com.sun.jna.Native
 import com.sun.jna.Pointer
 import com.sun.jna.Structure
+import com.sun.jna.Callback
 import com.sun.jna.ptr.*
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
@@ -34,29 +35,24 @@ import java.util.concurrent.ConcurrentHashMap
 @Structure.FieldOrder("capacity", "len", "data")
 open class RustBuffer : Structure() {
     @JvmField var capacity: Int = 0
-
     @JvmField var len: Int = 0
-
     @JvmField var data: Pointer? = null
 
-    class ByValue : RustBuffer(), Structure.ByValue
-
-    class ByReference : RustBuffer(), Structure.ByReference
+    class ByValue: RustBuffer(), Structure.ByValue
+    class ByReference: RustBuffer(), Structure.ByReference
 
     companion object {
-        internal fun alloc(size: Int = 0) =
-            rustCall { status ->
-                _UniFFILib.INSTANCE.ffi_bindings_rustbuffer_alloc(size, status).also {
-                    if (it.data == null) {
-                        throw RuntimeException("RustBuffer.alloc() returned null data pointer (size=$size)")
-                    }
-                }
+        internal fun alloc(size: Int = 0) = rustCall() { status ->
+            _UniFFILib.INSTANCE.ffi_bindings_rustbuffer_alloc(size, status).also {
+                if(it.data == null) {
+                   throw RuntimeException("RustBuffer.alloc() returned null data pointer (size=${size})")
+               }
             }
+        }
 
-        internal fun free(buf: RustBuffer.ByValue) =
-            rustCall { status ->
-                _UniFFILib.INSTANCE.ffi_bindings_rustbuffer_free(buf, status)
-            }
+        internal fun free(buf: RustBuffer.ByValue) = rustCall() { status ->
+            _UniFFILib.INSTANCE.ffi_bindings_rustbuffer_free(buf, status)
+        }
     }
 
     @Suppress("TooGenericExceptionThrown")
@@ -107,12 +103,10 @@ class RustBufferByReference : ByReference(16) {
 @Structure.FieldOrder("len", "data")
 open class ForeignBytes : Structure() {
     @JvmField var len: Int = 0
-
     @JvmField var data: Pointer? = null
 
     class ByValue : ForeignBytes(), Structure.ByValue
 }
-
 // The FfiConverter interface handles converter types to and from the FFI
 //
 // All implementing objects should be public to support external types.  When a
@@ -138,10 +132,7 @@ public interface FfiConverter<KotlinType, FfiType> {
     fun allocationSize(value: KotlinType): Int
 
     // Write a Kotlin type to a `ByteBuffer`
-    fun write(
-        value: KotlinType,
-        buf: ByteBuffer,
-    )
+    fun write(value: KotlinType, buf: ByteBuffer)
 
     // Lower a value into a `RustBuffer`
     //
@@ -152,10 +143,9 @@ public interface FfiConverter<KotlinType, FfiType> {
     fun lowerIntoRustBuffer(value: KotlinType): RustBuffer.ByValue {
         val rbuf = RustBuffer.alloc(allocationSize(value))
         try {
-            val bbuf =
-                rbuf.data!!.getByteBuffer(0, rbuf.capacity.toLong()).also {
-                    it.order(ByteOrder.BIG_ENDIAN)
-                }
+            val bbuf = rbuf.data!!.getByteBuffer(0, rbuf.capacity.toLong()).also {
+                it.order(ByteOrder.BIG_ENDIAN)
+            }
             write(value, bbuf)
             rbuf.writeField("len", bbuf.position())
             return rbuf
@@ -172,11 +162,11 @@ public interface FfiConverter<KotlinType, FfiType> {
     fun liftFromRustBuffer(rbuf: RustBuffer.ByValue): KotlinType {
         val byteBuf = rbuf.asByteBuffer()!!
         try {
-            val item = read(byteBuf)
-            if (byteBuf.hasRemaining()) {
-                throw RuntimeException("junk remaining in buffer after lifting, something is very wrong!!")
-            }
-            return item
+           val item = read(byteBuf)
+           if (byteBuf.hasRemaining()) {
+               throw RuntimeException("junk remaining in buffer after lifting, something is very wrong!!")
+           }
+           return item
         } finally {
             RustBuffer.free(rbuf)
         }
@@ -184,22 +174,19 @@ public interface FfiConverter<KotlinType, FfiType> {
 }
 
 // FfiConverter that uses `RustBuffer` as the FfiType
-public interface FfiConverterRustBuffer<KotlinType> : FfiConverter<KotlinType, RustBuffer.ByValue> {
+public interface FfiConverterRustBuffer<KotlinType>: FfiConverter<KotlinType, RustBuffer.ByValue> {
     override fun lift(value: RustBuffer.ByValue) = liftFromRustBuffer(value)
-
     override fun lower(value: KotlinType) = lowerIntoRustBuffer(value)
 }
-
 // A handful of classes and functions to support the generated data structures.
 // This would be a good candidate for isolating in its own ffi-support lib.
 // Error runtime.
 @Structure.FieldOrder("code", "error_buf")
 internal open class RustCallStatus : Structure() {
     @JvmField var code: Byte = 0
-
     @JvmField var error_buf: RustBuffer.ByValue = RustBuffer.ByValue()
 
-    class ByValue : RustCallStatus(), Structure.ByValue
+    class ByValue: RustCallStatus(), Structure.ByValue
 
     fun isSuccess(): Boolean {
         return code == 0.toByte()
@@ -218,7 +205,7 @@ class InternalException(message: String) : Exception(message)
 
 // Each top-level error class has a companion object that can lift the error from the call status's rust buffer
 interface CallStatusErrorHandler<E> {
-    fun lift(error_buf: RustBuffer.ByValue): E
+    fun lift(error_buf: RustBuffer.ByValue): E;
 }
 
 // Helpers for calling Rust
@@ -226,21 +213,15 @@ interface CallStatusErrorHandler<E> {
 // synchronize itself
 
 // Call a rust function that returns a Result<>.  Pass in the Error class companion that corresponds to the Err
-private inline fun <U, E : Exception> rustCallWithError(
-    errorHandler: CallStatusErrorHandler<E>,
-    callback: (RustCallStatus) -> U,
-): U {
-    var status = RustCallStatus()
+private inline fun <U, E: Exception> rustCallWithError(errorHandler: CallStatusErrorHandler<E>, callback: (RustCallStatus) -> U): U {
+    var status = RustCallStatus();
     val return_value = callback(status)
     checkCallStatus(errorHandler, status)
     return return_value
 }
 
 // Check RustCallStatus and throw an error if the call wasn't successful
-private fun <E : Exception> checkCallStatus(
-    errorHandler: CallStatusErrorHandler<E>,
-    status: RustCallStatus,
-) {
+private fun<E: Exception> checkCallStatus(errorHandler: CallStatusErrorHandler<E>, status: RustCallStatus) {
     if (status.isSuccess()) {
         return
     } else if (status.isError()) {
@@ -260,7 +241,7 @@ private fun <E : Exception> checkCallStatus(
 }
 
 // CallStatusErrorHandler implementation for times when we don't expect a CALL_ERROR
-object NullCallStatusErrorHandler : CallStatusErrorHandler<InternalException> {
+object NullCallStatusErrorHandler: CallStatusErrorHandler<InternalException> {
     override fun lift(error_buf: RustBuffer.ByValue): InternalException {
         RustBuffer.free(error_buf)
         return InternalException("Unexpected CALL_ERROR")
@@ -269,16 +250,14 @@ object NullCallStatusErrorHandler : CallStatusErrorHandler<InternalException> {
 
 // Call a rust function that returns a plain value
 private inline fun <U> rustCall(callback: (RustCallStatus) -> U): U {
-    return rustCallWithError(NullCallStatusErrorHandler, callback)
+    return rustCallWithError(NullCallStatusErrorHandler, callback);
 }
 
 // IntegerType that matches Rust's `usize` / C's `size_t`
 public class USize(value: Long = 0) : IntegerType(Native.SIZE_T_SIZE, value, true) {
     // This is needed to fill in the gaps of IntegerType's implementation of Number for Kotlin.
     override fun toByte() = toInt().toByte()
-
     override fun toChar() = toInt().toChar()
-
     override fun toShort() = toInt().toShort()
 
     fun writeToBuffer(buf: ByteBuffer) {
@@ -300,7 +279,7 @@ public class USize(value: Long = 0) : IntegerType(Native.SIZE_T_SIZE, value, tru
         val size: Int
             get() = Native.SIZE_T_SIZE
 
-        fun readFromBuffer(buf: ByteBuffer): USize {
+        fun readFromBuffer(buf: ByteBuffer) : USize {
             // Make sure we always read usize integers using native byte-order, since they may be
             // casted from pointer values
             buf.order(ByteOrder.nativeOrder())
@@ -317,6 +296,7 @@ public class USize(value: Long = 0) : IntegerType(Native.SIZE_T_SIZE, value, tru
     }
 }
 
+
 // Map handles to objects
 //
 // This is used when the Rust code expects an opaque pointer to represent some foreign object.
@@ -327,9 +307,8 @@ public class USize(value: Long = 0) : IntegerType(Native.SIZE_T_SIZE, value, tru
 // Rust when it needs an opaque pointer.
 //
 // TODO: refactor callbacks to use this class
-internal class UniFfiHandleMap<T : Any> {
+internal class UniFfiHandleMap<T: Any> {
     private val map = ConcurrentHashMap<USize, T>()
-
     // Use AtomicInteger for our counter, since we may be on a 32-bit system.  4 billion possible
     // values seems like enough. If somehow we generate 4 billion handles, then this will wrap
     // around back to zero and we can assume the first handle generated will have been dropped by
@@ -365,7 +344,9 @@ private fun findLibraryName(componentName: String): String {
     return "uniffi_bindings"
 }
 
-private inline fun <reified Lib : Library> loadIndirect(componentName: String): Lib {
+private inline fun <reified Lib : Library> loadIndirect(
+    componentName: String
+): Lib {
     return Native.load<Lib>(findLibraryName(componentName), Lib::class.java)
 }
 
@@ -376,52 +357,32 @@ internal interface _UniFFILib : Library {
     companion object {
         internal val INSTANCE: _UniFFILib by lazy {
             loadIndirect<_UniFFILib>(componentName = "bindings")
-                .also { lib: _UniFFILib ->
-                    uniffiCheckContractApiVersion(lib)
-                    uniffiCheckApiChecksums(lib)
+            .also { lib: _UniFFILib ->
+                uniffiCheckContractApiVersion(lib)
+                uniffiCheckApiChecksums(lib)
                 }
         }
     }
 
-    fun uniffi_bindings_fn_func_attest_connection(
-        `cert`: RustBuffer.ByValue,
-        `expectedPcrsList`: RustBuffer.ByValue,
-        _uniffi_out_err: RustCallStatus,
+    fun uniffi_bindings_fn_func_attest_connection(`cert`: RustBuffer.ByValue,`expectedPcrsList`: RustBuffer.ByValue,_uniffi_out_err: RustCallStatus, 
     ): Byte
-
-    fun uniffi_bindings_fn_func_attest_cage(
-        `cert`: RustBuffer.ByValue,
-        `expectedPcrsList`: RustBuffer.ByValue,
-        `attestationDoc`: RustBuffer.ByValue,
-        _uniffi_out_err: RustCallStatus,
+    fun uniffi_bindings_fn_func_attest_cage(`cert`: RustBuffer.ByValue,`expectedPcrsList`: RustBuffer.ByValue,`attestationDoc`: RustBuffer.ByValue,_uniffi_out_err: RustCallStatus, 
     ): Byte
-
-    fun ffi_bindings_rustbuffer_alloc(
-        `size`: Int,
-        _uniffi_out_err: RustCallStatus,
+    fun ffi_bindings_rustbuffer_alloc(`size`: Int,_uniffi_out_err: RustCallStatus, 
     ): RustBuffer.ByValue
-
-    fun ffi_bindings_rustbuffer_from_bytes(
-        `bytes`: ForeignBytes.ByValue,
-        _uniffi_out_err: RustCallStatus,
+    fun ffi_bindings_rustbuffer_from_bytes(`bytes`: ForeignBytes.ByValue,_uniffi_out_err: RustCallStatus, 
     ): RustBuffer.ByValue
-
-    fun ffi_bindings_rustbuffer_free(
-        `buf`: RustBuffer.ByValue,
-        _uniffi_out_err: RustCallStatus,
+    fun ffi_bindings_rustbuffer_free(`buf`: RustBuffer.ByValue,_uniffi_out_err: RustCallStatus, 
     ): Unit
-
-    fun ffi_bindings_rustbuffer_reserve(
-        `buf`: RustBuffer.ByValue,
-        `additional`: Int,
-        _uniffi_out_err: RustCallStatus,
+    fun ffi_bindings_rustbuffer_reserve(`buf`: RustBuffer.ByValue,`additional`: Int,_uniffi_out_err: RustCallStatus, 
     ): RustBuffer.ByValue
-
-    fun uniffi_bindings_checksum_func_attest_connection(): Short
-
-    fun uniffi_bindings_checksum_func_attest_cage(): Short
-
-    fun ffi_bindings_uniffi_contract_version(): Int
+    fun uniffi_bindings_checksum_func_attest_connection(
+    ): Short
+    fun uniffi_bindings_checksum_func_attest_cage(
+    ): Short
+    fun ffi_bindings_uniffi_contract_version(
+    ): Int
+    
 }
 
 private fun uniffiCheckContractApiVersion(lib: _UniFFILib) {
@@ -446,7 +407,8 @@ private fun uniffiCheckApiChecksums(lib: _UniFFILib) {
 
 // Public interface members begin here.
 
-public object FfiConverterBoolean : FfiConverter<Boolean, Byte> {
+
+public object FfiConverterBoolean: FfiConverter<Boolean, Byte> {
     override fun lift(value: Byte): Boolean {
         return value.toInt() != 0
     }
@@ -461,15 +423,12 @@ public object FfiConverterBoolean : FfiConverter<Boolean, Byte> {
 
     override fun allocationSize(value: Boolean) = 1
 
-    override fun write(
-        value: Boolean,
-        buf: ByteBuffer,
-    ) {
+    override fun write(value: Boolean, buf: ByteBuffer) {
         buf.put(lower(value))
     }
 }
 
-public object FfiConverterString : FfiConverter<String, RustBuffer.ByValue> {
+public object FfiConverterString: FfiConverter<String, RustBuffer.ByValue> {
     // Note: we don't inherit from FfiConverterRustBuffer, because we use a
     // special encoding when lowering/lifting.  We can use `RustBuffer.len` to
     // store our length and avoid writing it out to the buffer.
@@ -508,74 +467,99 @@ public object FfiConverterString : FfiConverter<String, RustBuffer.ByValue> {
         return sizeForLength + sizeForString
     }
 
-    override fun write(
-        value: String,
-        buf: ByteBuffer,
-    ) {
+    override fun write(value: String, buf: ByteBuffer) {
         val byteArr = value.toByteArray(Charsets.UTF_8)
         buf.putInt(byteArr.size)
         buf.put(byteArr)
     }
 }
 
-public object FfiConverterByteArray : FfiConverterRustBuffer<ByteArray> {
+public object FfiConverterByteArray: FfiConverterRustBuffer<ByteArray> {
     override fun read(buf: ByteBuffer): ByteArray {
         val len = buf.getInt()
         val byteArr = ByteArray(len)
         buf.get(byteArr)
         return byteArr
     }
-
     override fun allocationSize(value: ByteArray): Int {
         return 4 + value.size
     }
-
-    override fun write(
-        value: ByteArray,
-        buf: ByteBuffer,
-    ) {
+    override fun write(value: ByteArray, buf: ByteBuffer) {
         buf.putInt(value.size)
         buf.put(value)
     }
 }
 
-data class PcRs(
-    var `pcr0`: String,
-    var `pcr1`: String,
-    var `pcr2`: String,
-    var `pcr8`: String,
-)
 
-public object FfiConverterTypePCRs : FfiConverterRustBuffer<PcRs> {
+
+
+data class PcRs (
+    var `pcr0`: String?, 
+    var `pcr1`: String?, 
+    var `pcr2`: String?, 
+    var `pcr8`: String?
+) {
+    
+}
+
+public object FfiConverterTypePCRs: FfiConverterRustBuffer<PcRs> {
     override fun read(buf: ByteBuffer): PcRs {
         return PcRs(
-            FfiConverterString.read(buf),
-            FfiConverterString.read(buf),
-            FfiConverterString.read(buf),
-            FfiConverterString.read(buf),
+            FfiConverterOptionalString.read(buf),
+            FfiConverterOptionalString.read(buf),
+            FfiConverterOptionalString.read(buf),
+            FfiConverterOptionalString.read(buf),
         )
     }
 
-    override fun allocationSize(value: PcRs) =
-        (
-            FfiConverterString.allocationSize(value.`pcr0`) +
-                FfiConverterString.allocationSize(value.`pcr1`) +
-                FfiConverterString.allocationSize(value.`pcr2`) +
-                FfiConverterString.allocationSize(value.`pcr8`)
-        )
+    override fun allocationSize(value: PcRs) = (
+            FfiConverterOptionalString.allocationSize(value.`pcr0`) +
+            FfiConverterOptionalString.allocationSize(value.`pcr1`) +
+            FfiConverterOptionalString.allocationSize(value.`pcr2`) +
+            FfiConverterOptionalString.allocationSize(value.`pcr8`)
+    )
 
-    override fun write(
-        value: PcRs,
-        buf: ByteBuffer,
-    ) {
-        FfiConverterString.write(value.`pcr0`, buf)
-        FfiConverterString.write(value.`pcr1`, buf)
-        FfiConverterString.write(value.`pcr2`, buf)
-        FfiConverterString.write(value.`pcr8`, buf)
+    override fun write(value: PcRs, buf: ByteBuffer) {
+            FfiConverterOptionalString.write(value.`pcr0`, buf)
+            FfiConverterOptionalString.write(value.`pcr1`, buf)
+            FfiConverterOptionalString.write(value.`pcr2`, buf)
+            FfiConverterOptionalString.write(value.`pcr8`, buf)
     }
 }
 
-public object FfiConverterSequenceTypePCRs : FfiConverterRustBuffer<List<PcRs>> {
+
+
+
+public object FfiConverterOptionalString: FfiConverterRustBuffer<String?> {
+    override fun read(buf: ByteBuffer): String? {
+        if (buf.get().toInt() == 0) {
+            return null
+        }
+        return FfiConverterString.read(buf)
+    }
+
+    override fun allocationSize(value: String?): Int {
+        if (value == null) {
+            return 1
+        } else {
+            return 1 + FfiConverterString.allocationSize(value)
+        }
+    }
+
+    override fun write(value: String?, buf: ByteBuffer) {
+        if (value == null) {
+            buf.put(0)
+        } else {
+            buf.put(1)
+            FfiConverterString.write(value, buf)
+        }
+    }
+}
+
+
+
+
+public object FfiConverterSequenceTypePCRs: FfiConverterRustBuffer<List<PcRs>> {
     override fun read(buf: ByteBuffer): List<PcRs> {
         val len = buf.getInt()
         return List<PcRs>(len) {
@@ -589,10 +573,7 @@ public object FfiConverterSequenceTypePCRs : FfiConverterRustBuffer<List<PcRs>> 
         return sizeForLength + sizeForItems
     }
 
-    override fun write(
-        value: List<PcRs>,
-        buf: ByteBuffer,
-    ) {
+    override fun write(value: List<PcRs>, buf: ByteBuffer) {
         buf.putInt(value.size)
         value.forEach {
             FfiConverterTypePCRs.write(it, buf)
@@ -600,34 +581,19 @@ public object FfiConverterSequenceTypePCRs : FfiConverterRustBuffer<List<PcRs>> 
     }
 }
 
-fun `attestConnection`(
-    `cert`: ByteArray,
-    `expectedPcrsList`: List<PcRs>,
-): Boolean {
+fun `attestConnection`(`cert`: ByteArray, `expectedPcrsList`: List<PcRs>): Boolean {
     return FfiConverterBoolean.lift(
-        rustCall { _status ->
-            _UniFFILib.INSTANCE.uniffi_bindings_fn_func_attest_connection(
-                FfiConverterByteArray.lower(`cert`),
-                FfiConverterSequenceTypePCRs.lower(`expectedPcrsList`),
-                _status,
-            )
-        },
-    )
+    rustCall() { _status ->
+    _UniFFILib.INSTANCE.uniffi_bindings_fn_func_attest_connection(FfiConverterByteArray.lower(`cert`),FfiConverterSequenceTypePCRs.lower(`expectedPcrsList`),_status)
+})
 }
 
-fun `attestCage`(
-    `cert`: ByteArray,
-    `expectedPcrsList`: List<PcRs>,
-    `attestationDoc`: ByteArray,
-): Boolean {
+
+fun `attestCage`(`cert`: ByteArray, `expectedPcrsList`: List<PcRs>, `attestationDoc`: ByteArray): Boolean {
     return FfiConverterBoolean.lift(
-        rustCall { _status ->
-            _UniFFILib.INSTANCE.uniffi_bindings_fn_func_attest_cage(
-                FfiConverterByteArray.lower(`cert`),
-                FfiConverterSequenceTypePCRs.lower(`expectedPcrsList`),
-                FfiConverterByteArray.lower(`attestationDoc`),
-                _status,
-            )
-        },
-    )
+    rustCall() { _status ->
+    _UniFFILib.INSTANCE.uniffi_bindings_fn_func_attest_cage(FfiConverterByteArray.lower(`cert`),FfiConverterSequenceTypePCRs.lower(`expectedPcrsList`),FfiConverterByteArray.lower(`attestationDoc`),_status)
+})
 }
+
+


### PR DESCRIPTION
# Why
You can now pass a single PCR to attest a connection to an enclave

# How
- Update the UDL file to use Option for pcrs
- Change the PCR struct to use new type
- Regenerate the Kotlin bindings
