### PR TITLE
update remove references to cage

### DIFF
--- a/kotlin-attestation-bindings/src/bindings.udl
+++ b/kotlin-attestation-bindings/src/bindings.udl
@@ -1,6 +1,6 @@
 namespace bindings {
   boolean attest_connection(bytes cert, sequence<PCRs> expected_pcrs_list);
-  boolean attest_cage(bytes cert, sequence<PCRs> expected_pcrs_list, bytes attestation_doc);
+  boolean attest_enclave(bytes cert, sequence<PCRs> expected_pcrs_list, bytes attestation_doc);
 };
 
 dictionary PCRs {

--- a/kotlin-attestation-bindings/src/lib.rs
+++ b/kotlin-attestation-bindings/src/lib.rs
@@ -39,7 +39,7 @@ pub fn attest_connection(cert: Vec<u8>, expected_pcrs_list: Vec<PCRs>) -> bool {
     let validated_attestation_doc = match validate_attestation_doc_in_cert(&parsed_cert) {
         Ok(attestation_doc) => attestation_doc,
         Err(e) => {
-            eprintln!("An error occurred while validating the connection to this Cage: {e}");
+            eprintln!("An error occurred while validating the connection to this Enclave: {e}");
             return false;
         }
     };
@@ -62,7 +62,7 @@ pub fn attest_connection(cert: Vec<u8>, expected_pcrs_list: Vec<PCRs>) -> bool {
 }
 
 
-pub fn attest_cage(cert: Vec<u8>, expected_pcrs_list: Vec<PCRs>, attestation_doc: Vec<u8>) -> bool {
+pub fn attest_enclave(cert: Vec<u8>, expected_pcrs_list: Vec<PCRs>, attestation_doc: Vec<u8>) -> bool {
     let parsed_cert = match parse_cert(&cert) {
         Ok(parsed_cert) => parsed_cert,
         Err(e) => {
@@ -74,7 +74,7 @@ pub fn attest_cage(cert: Vec<u8>, expected_pcrs_list: Vec<PCRs>, attestation_doc
     let validated_attestation_doc = match validate_attestation_doc_against_cert(&parsed_cert, &attestation_doc) {
         Ok(attestation_doc) => attestation_doc,
         Err(e) => {
-            eprintln!("An error occurred while validating the connection to this Cage: {e}");
+            eprintln!("An error occurred while validating the connection to this Enclave: {e}");
             return false;
         }
     };

--- a/kotlin-attestation-bindings/src/uniffi/bindings/bindings.kt
+++ b/kotlin-attestation-bindings/src/uniffi/bindings/bindings.kt
@@ -366,7 +366,7 @@ internal interface _UniFFILib : Library {
 
     fun uniffi_bindings_fn_func_attest_connection(`cert`: RustBuffer.ByValue,`expectedPcrsList`: RustBuffer.ByValue,_uniffi_out_err: RustCallStatus, 
     ): Byte
-    fun uniffi_bindings_fn_func_attest_cage(`cert`: RustBuffer.ByValue,`expectedPcrsList`: RustBuffer.ByValue,`attestationDoc`: RustBuffer.ByValue,_uniffi_out_err: RustCallStatus, 
+    fun uniffi_bindings_fn_func_attest_enclave(`cert`: RustBuffer.ByValue,`expectedPcrsList`: RustBuffer.ByValue,`attestationDoc`: RustBuffer.ByValue,_uniffi_out_err: RustCallStatus, 
     ): Byte
     fun ffi_bindings_rustbuffer_alloc(`size`: Int,_uniffi_out_err: RustCallStatus, 
     ): RustBuffer.ByValue
@@ -378,7 +378,7 @@ internal interface _UniFFILib : Library {
     ): RustBuffer.ByValue
     fun uniffi_bindings_checksum_func_attest_connection(
     ): Short
-    fun uniffi_bindings_checksum_func_attest_cage(
+    fun uniffi_bindings_checksum_func_attest_enclave(
     ): Short
     fun ffi_bindings_uniffi_contract_version(
     ): Int
@@ -400,7 +400,7 @@ private fun uniffiCheckApiChecksums(lib: _UniFFILib) {
     if (lib.uniffi_bindings_checksum_func_attest_connection() != 58635.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
-    if (lib.uniffi_bindings_checksum_func_attest_cage() != 59539.toShort()) {
+    if (lib.uniffi_bindings_checksum_func_attest_enclave() != 14194.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
 }
@@ -589,10 +589,10 @@ fun `attestConnection`(`cert`: ByteArray, `expectedPcrsList`: List<PcRs>): Boole
 }
 
 
-fun `attestCage`(`cert`: ByteArray, `expectedPcrsList`: List<PcRs>, `attestationDoc`: ByteArray): Boolean {
+fun `attestEnclave`(`cert`: ByteArray, `expectedPcrsList`: List<PcRs>, `attestationDoc`: ByteArray): Boolean {
     return FfiConverterBoolean.lift(
     rustCall() { _status ->
-    _UniFFILib.INSTANCE.uniffi_bindings_fn_func_attest_cage(FfiConverterByteArray.lower(`cert`),FfiConverterSequenceTypePCRs.lower(`expectedPcrsList`),FfiConverterByteArray.lower(`attestationDoc`),_status)
+    _UniFFILib.INSTANCE.uniffi_bindings_fn_func_attest_enclave(FfiConverterByteArray.lower(`cert`),FfiConverterSequenceTypePCRs.lower(`expectedPcrsList`),FfiConverterByteArray.lower(`attestationDoc`),_status)
 })
 }
 


### PR DESCRIPTION
# Why
Updating kotlin attestation bindings to use enclave instead of cage
# How
- refactor references to Cage
