### PR TITLE
Prepare node bindings for v1 release

### DIFF
--- a/node-attestation-bindings/package.json
+++ b/node-attestation-bindings/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@evervault/attestation-bindings",
-  "version": "1.0.0-rc.1",
+  "version": "1.0.0",
   "main": "index.js",
   "types": "index.d.ts",
   "napi": {


### PR DESCRIPTION
# Why
V1 release of node bindings under new namespace

# How
Update package version to v1.
