### PR TITLE
Add more context to untrusted cert error

### DIFF
--- a/.github/workflows/build-and-deploy-node-bindings.yml
+++ b/.github/workflows/build-and-deploy-node-bindings.yml
@@ -26,7 +26,7 @@ jobs:
           - host: macos-latest
             target: x86_64-apple-darwin
             build: |
-              yarn build
+              yarn build --target x86_64-apple-darwin
               strip -x *.node
           - host: windows-latest
             build: yarn build

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -176,7 +176,7 @@ dependencies = [
 
 [[package]]
 name = "attestation-doc-validation"
-version = "0.7.4"
+version = "0.8.0"
 dependencies = [
  "aes",
  "aes-gcm",

--- a/attestation-doc-validation/Cargo.toml
+++ b/attestation-doc-validation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "attestation-doc-validation"
-version = "0.7.4"
+version = "0.8.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "A Rust library for attesting enclaves according to the Evervault Attestation scheme. This crate is used to generate ffi bindings."

--- a/attestation-doc-validation/src/cert.rs
+++ b/attestation-doc-validation/src/cert.rs
@@ -1,8 +1,5 @@
 //! Module for parsing and validating X509 certs
-use super::{
-    error::{CertError, CertResult},
-    true_or_invalid,
-};
+use super::error::{CertError, CertResult};
 use serde_bytes::ByteBuf;
 use std::str::FromStr;
 use webpki::{EndEntityCert, TrustAnchor};
@@ -127,17 +124,14 @@ pub fn validate_cert_trust_chain(target: &[u8], intermediates: &[&[u8]]) -> Cert
     let now = get_epoch()?;
     let time = webpki::Time::from_seconds_since_unix_epoch(now);
 
-    true_or_invalid(
-        end_entity_cert
-            .verify_is_valid_tls_server_cert(
-                SUPPORTED_SIG_ALGS,
-                &server_trust_anchors,
-                intermediates,
-                time,
-            )
-            .is_ok(),
-        CertError::UntrustedCert,
-    )
+    end_entity_cert.verify_is_valid_tls_server_cert(
+        SUPPORTED_SIG_ALGS,
+        &server_trust_anchors,
+        intermediates,
+        time,
+    )?;
+
+    Ok(())
 }
 
 pub(super) fn parse_der_cert(cert: &[u8]) -> CertResult<X509Certificate<'_>> {

--- a/attestation-doc-validation/src/error.rs
+++ b/attestation-doc-validation/src/error.rs
@@ -84,7 +84,7 @@ pub enum CertError
 where
     Self: Send + Sync,
 {
-    // Webpki errors don't implement stderr, so must be serialized before wrapping in custome err.
+    // Webpki errors don't implement stderr, so must be serialized before wrapping in custom err.
     #[error("Failed to validate the trust chain for the provided cert — {0}")]
     InvalidTrustChain(String),
     #[error("The certificate in the attestation doc was detected as not having the NSM as root")]

--- a/attestation-doc-validation/src/error.rs
+++ b/attestation-doc-validation/src/error.rs
@@ -84,6 +84,9 @@ pub enum CertError
 where
     Self: Send + Sync,
 {
+    // Webpki errors don't implement stderr, so must be serialized before wrapping in custome err.
+    #[error("Failed to validate the trust chain for the provided cert — {0}")]
+    InvalidTrustChain(String),
     #[error("The certificate in the attestation doc was detected as not having the NSM as root")]
     UntrustedCert,
     #[error("The received certificate had no Subject Alt Name extension")]
@@ -102,4 +105,10 @@ where
     X509Error,
     #[error("No cert given")]
     NoCertGiven,
+}
+
+impl std::convert::From<webpki::Error> for CertError {
+    fn from(value: webpki::Error) -> Self {
+        Self::InvalidTrustChain(value.to_string())
+    }
 }

--- a/attestation-doc-validation/src/lib.rs
+++ b/attestation-doc-validation/src/lib.rs
@@ -215,7 +215,7 @@ mod test {
         let err = validate_attestation_doc_in_cert(&cert).unwrap_err();
         assert!(matches!(
             err,
-            error::AttestError::CertError(error::CertError::UntrustedCert)
+            error::AttestError::CertError(error::CertError::InvalidTrustChain(_))
         ));
     }
 


### PR DESCRIPTION
# Why
When an attestation doc is rejected for an untrusted cert chain, we currently return a generic error message which gives no insight into the root cause.

# How
Update the returned error for an invalid trust chain and embed the serialized error from the webpki crate.
