### PR TITLE
chore: pin toolchain version for python test workflow

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -54,9 +54,11 @@ jobs:
       - uses: actions/checkout@v3
       - uses: PyO3/maturin-action@v1
         with:
+          manylinux: '2_28'
           command: build
           args: --release -o dist --find-interpreter
           working-directory: python-attestation-bindings
+          rust-toolchain: 1.79.0 
         env:
           PYO3_CROSS_PYTHON_VERSION: "3.9"
       - name: Build and Test


### PR DESCRIPTION
# Why
Test workflow is failing on main

# How
Pin rust toolchain