### PR TITLE
Alias Rust types to have JS Friendly casing, constructors and setters

### DIFF
--- a/wasm-attestation-bindings/README.md
+++ b/wasm-attestation-bindings/README.md
@@ -1,0 +1,38 @@
+# Wasm Attestation Bindings
+
+This project contains the WASM interface for validating the PCRs presented in an Enclave attestation document in the Browser.
+
+The attestation model in the browser differs slightly from that of backend SDKs, as the browser does not expose the Enclave's TLS
+public key. This means that the attestation step only verifies the integrity and contents of the attestation document it has been given and not the
+integrity of the connection. 
+
+The wasm bindings can be tested using the static HTML client in `example.html`. To use it, the file must be served from a webserver to allow the browser
+to load and register the wasm. This can be done using php (`php -S 127.0.0.1:8080`), python (`python -m http.server 8080`) or any preferred
+web server.
+
+## Usage
+
+To validate the attestation doc for an Enclave, the attestation doc must first be loaded into the browser from the `.well-known` endpoint:
+
+```js
+const { attestation_doc: attestationDoc } = await fetch(`https://${enclaveHostname}/.well-known/attestation`).then(res => res.json());
+```
+
+The doc can then be verified using the expected PCRs:
+
+```js
+const pcrContainer = PCRs.empty();
+pcrContainer.pcr0 = "my-pcr0";
+const result = validateAttestationDocPcrs(attestationDoc, expectedPcrs);
+if(!result) {
+  throw new Error('Enclave failed to provide expected PCRs');
+}
+```
+
+This will return a boolean reflecting whether or not the atestation doc represents the expected PCRs. 
+
+## Note on High Traffic Volume Apps
+
+As Enclaves are I/O constrained, they will struggle to serve high traffic volumes. This should be factored into the scoping of the in-Enclave
+service, and the implementation of the client code calling into the Enclave to ensure that it can handle increases in latency when requesting 
+the Enclave, and has a reasonable back-off policy.

--- a/wasm-attestation-bindings/example.html
+++ b/wasm-attestation-bindings/example.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Example Browser Attestation Client</title>
+</head>
+<body>
+  <script type="module">
+    import init, { validateAttestationDocPcrs, PCRs } from './pkg/index.js';
+
+    function readInput(id) {
+      return document.getElementById(id).value;
+    }
+
+    function setText(id, value) {
+      document.getElementById(id).innerText = value;
+    }
+
+    let initializationPromise = init();
+    async function run() {
+      setText('error', '');
+      setText('result', '');
+      try {
+        await initializationPromise;
+        const pcrContainer = PCRs.empty();
+        pcrContainer.pcr0 = readInput('expected-pcr0');
+        const expectedPcrs = [pcrContainer];
+        const enclaveHostname = readInput('enclave-hostname');
+        const { attestation_doc: attestationDoc } = await fetch(`https://${enclaveHostname}/.well-known/attestation`).then(res => res.json());
+        console.log(expectedPcrs);
+        const result = validateAttestationDocPcrs(attestationDoc, expectedPcrs);
+        console.log("Attestation doc validation result:", result);
+        setText('result', result ? 'Success' : 'Failure');
+      } catch (e) {
+        console.error(e);
+        setText('error', e.message);
+      }
+    }
+    document.getElementById('run-attest').addEventListener('click', run);
+  </script>
+
+  <div>
+    <div>
+      <p>Enter your enclave hostname:</p>
+      <input type="text" id="enclave-hostname" value="my-enclave.app_deadbeef.enclave.evervault.com" />
+    </div>
+    <div>
+      <p>Enter your expected pcr0 value:</p>
+      <input type="text" id="expected-pcr0" value="MY_PCR0" />
+    </div>
+    <button id="run-attest">Attest</button>
+    <p>Attestation result: <span id="result" style="font-weight:bold"></span></p>
+    <p id="error" style="color:red"></p>
+  </div>
+</body>
+</html>

--- a/wasm-attestation-bindings/src/lib.rs
+++ b/wasm-attestation-bindings/src/lib.rs
@@ -16,16 +16,22 @@ extern "C" {
     fn error(s: &str);
 }
 
-#[wasm_bindgen(getter_with_clone)]
+// PCR class for mapping between JS and rust.
+#[wasm_bindgen(js_name = PCRs)]
 pub struct JsPCRs {
+    #[wasm_bindgen(getter_with_clone, js_name = hashAlgorithm)]
     pub hash_algorithm: Option<String>,
+    #[wasm_bindgen(getter_with_clone, js_name = pcr0)]
     pub pcr_0: Option<String>,
+    #[wasm_bindgen(getter_with_clone, js_name = pcr1)]
     pub pcr_1: Option<String>,
+    #[wasm_bindgen(getter_with_clone, js_name = pcr2)]
     pub pcr_2: Option<String>,
+    #[wasm_bindgen(getter_with_clone, js_name = pcr8)]
     pub pcr_8: Option<String>,
 }
 
-#[wasm_bindgen]
+#[wasm_bindgen(js_class = PCRs)]
 impl JsPCRs {
     #[wasm_bindgen(constructor)]
     pub fn new(
@@ -44,6 +50,12 @@ impl JsPCRs {
       }
     }
 
+    /// Helper to create an empty PCR container, to support setting the PCRs explicitly
+    /// ```js
+    /// const pcrs = PCRs.empty();
+    /// pcrs.pcr0 = "...";
+    /// pcrs.pcr8 = "...";
+    /// ```
     pub fn empty() -> Self {
       Self {
         pcr_0: None,
@@ -52,31 +64,6 @@ impl JsPCRs {
         pcr_8: None,
         hash_algorithm: None
       }
-    }
-
-    #[wasm_bindgen(js_name = setPcr0)]
-    pub fn set_pcr0(&mut self, pcr_0: String) {
-      self.pcr_0 = Some(pcr_0);
-    }
-
-    #[wasm_bindgen(js_name = setPcr1)]
-    pub fn set_pcr1(&mut self, pcr_1: String) {
-      self.pcr_1 = Some(pcr_1);
-    }
-
-    #[wasm_bindgen(js_name = setPcr2)]
-    pub fn set_pcr2(&mut self, pcr_2: String) {
-      self.pcr_2 = Some(pcr_2);
-    }
-
-    #[wasm_bindgen(js_name = setPcr8)]
-    pub fn set_pcr8(&mut self, pcr_8: String) {
-      self.pcr_8 = Some(pcr_8);
-    }
-
-    #[wasm_bindgen(js_name = setHashAlgorithm)]
-    pub fn set_hash_algorithm(&mut self, hash_algorithm: String) {
-      self.hash_algorithm = Some(hash_algorithm);
     }
 }
 

--- a/wasm-attestation-bindings/src/lib.rs
+++ b/wasm-attestation-bindings/src/lib.rs
@@ -25,6 +25,61 @@ pub struct JsPCRs {
     pub pcr_8: Option<String>,
 }
 
+#[wasm_bindgen]
+impl JsPCRs {
+    #[wasm_bindgen(constructor)]
+    pub fn new(
+        pcr_0: Option<String>,
+        pcr_1: Option<String>,
+        pcr_2: Option<String>,
+        pcr_8: Option<String>,
+        hash_algorithm: Option<String>,
+    ) -> Self {
+      Self {
+        pcr_0,
+        pcr_1,
+        pcr_2,
+        pcr_8,
+        hash_algorithm
+      }
+    }
+
+    pub fn empty() -> Self {
+      Self {
+        pcr_0: None,
+        pcr_1: None,
+        pcr_2: None,
+        pcr_8: None,
+        hash_algorithm: None
+      }
+    }
+
+    #[wasm_bindgen(js_name = setPcr0)]
+    pub fn set_pcr0(&mut self, pcr_0: String) {
+      self.pcr_0 = Some(pcr_0);
+    }
+
+    #[wasm_bindgen(js_name = setPcr1)]
+    pub fn set_pcr1(&mut self, pcr_1: String) {
+      self.pcr_1 = Some(pcr_1);
+    }
+
+    #[wasm_bindgen(js_name = setPcr2)]
+    pub fn set_pcr2(&mut self, pcr_2: String) {
+      self.pcr_2 = Some(pcr_2);
+    }
+
+    #[wasm_bindgen(js_name = setPcr8)]
+    pub fn set_pcr8(&mut self, pcr_8: String) {
+      self.pcr_8 = Some(pcr_8);
+    }
+
+    #[wasm_bindgen(js_name = setHashAlgorithm)]
+    pub fn set_hash_algorithm(&mut self, hash_algorithm: String) {
+      self.hash_algorithm = Some(hash_algorithm);
+    }
+}
+
 impl PCRProvider for JsPCRs {
     fn pcr_0(&self) -> Option<&str> {
         self.pcr_0.as_deref()
@@ -47,7 +102,9 @@ const LOG_NAMESPACE: &'static str = "ATTESTATION ::";
 
 /// A client can call out to `<enclave-url>/.well-known/attestation` to fetch the attestation doc from the Enclave
 /// The fetched attestation doc will have the public key of the domain's cert embedded inside it along with an expiry
-#[wasm_bindgen]
+/// Note: this is the typical attestation flow used in our server side SDK, but is unlikely to be usable in browser
+/// as there's no access to the Remote TLS Certificate. You likely need the validateAttestationDocPcrs function.
+#[wasm_bindgen(js_name = attestEnclave)]
 pub fn attest_enclave(
     cert: Box<[u8]>,
     expected_pcrs_list: Box<[JsPCRs]>,
@@ -106,7 +163,7 @@ pub fn attest_enclave(
 
 /// A client can call out to `<enclave-url>/.well-known/attestation` to fetch the attestation doc from the Enclave
 /// The fetched attestation doc will have the public key of the domain's cert embedded inside it along with an expiry
-#[wasm_bindgen]
+#[wasm_bindgen(js_name = validateAttestationDocPcrs)]
 pub fn validate_attestation_doc_pcrs(
     attestation_doc: &str,
     expected_pcrs_list: Box<[JsPCRs]>,


### PR DESCRIPTION
# Why

Initial impl of the PCR container in rust exposed to JS was leaking the FFI interface through it's naming convention (snake case, and `Js` prefix on types). It also omitted the constructor, which rendered the PCRs inaccessible.

# How

Add aliases to improve naming of exposed JS interface:
- `JsPCRs` -> `PCRs`
- `PCRs.pcr_X` -> `PCRs.pcrX`
- Expose new `empty` API for `PCRs` to avoid passing many `undefined`s to the constructor.
- Add README discussing the difference in trust model for browser vs backend clients
- Add tiny html client example.