### PR TITLE
Update Cargo.toml version to 0.10.0

### DIFF
--- a/attestation-doc-validation/Cargo.toml
+++ b/attestation-doc-validation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "attestation-doc-validation"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "A Rust library for attesting enclaves according to the Evervault Attestation scheme. This crate is used to generate ffi bindings."


### PR DESCRIPTION
# Why

Version needs to match next release

# How

Bump rust crate version to 0.10.0
