### PR TITLE
chore: update python version for release

### DIFF
--- a/python-attestation-bindings/pyproject.toml
+++ b/python-attestation-bindings/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "evervault_attestation_bindings"
-version = "0.3.3"
+version = "0.4.0"
 requires-python = ">=3.6"
 classifiers = [
   "Programming Language :: Rust",


### PR DESCRIPTION
# Why

The python bindings are being prepped for release, so need to be moved to 0.4.0

# How

Bump version in pyproject.toml