### PR TITLE
fix: python release workflow attempted to download all artifacts by by pattern

### DIFF
--- a/.github/workflows/build-and-deploy-python-bindings.yml
+++ b/.github/workflows/build-and-deploy-python-bindings.yml
@@ -105,7 +105,6 @@ jobs:
       - uses: actions/download-artifact@v4.1.8
         with:
           path: python-attestation-bindings/wheels
-          name: wheels
           pattern: wheels-*
           merge-multiple: true
       - name: Publish to PyPI


### PR DESCRIPTION
# Why

Download artifact workflow was incorrectly configured, attempting to download by name and pattern.

# How

Removed name option