### PR TITLE
Add tag trigger for wasm

### DIFF
--- a/.github/workflows/build-and-deploy-wasm-bindings.yml
+++ b/.github/workflows/build-and-deploy-wasm-bindings.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+    tags:
+      - 'wasm/v*'
     paths:
       - 'wasm-attestation-bindings/**'
       - 'attestation-doc-validation/**'


### PR DESCRIPTION
# Why
The release build didnt trigger because the tag was missing

# How
Add tag trigger to workflow
