### PR TITLE
Fix rust version to 1.79 for wasm release

### DIFF
--- a/.github/workflows/build-and-deploy-wasm-bindings.yml
+++ b/.github/workflows/build-and-deploy-wasm-bindings.yml
@@ -52,6 +52,13 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
+      - name: Set up Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: 1.79.0
+          override: true
+          target: wasm32-unknown-unknown
+
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/build-and-deploy-wasm-bindings.yml
+++ b/.github/workflows/build-and-deploy-wasm-bindings.yml
@@ -10,7 +10,7 @@ on:
       - 'wasm-attestation-bindings/**'
       - 'attestation-doc-validation/**'
       - '.github/workflows/build-and-deploy-wasm-bindings.yml'
-
+  pull_request: 
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-and-deploy-wasm-bindings.yml
+++ b/.github/workflows/build-and-deploy-wasm-bindings.yml
@@ -20,10 +20,8 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up Rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@4a967c1422bcefedc3e9d03815f71eecdc71e5b7
         with:
-          toolchain: 1.79.0
-          override: true
           target: wasm32-unknown-unknown
 
       # wasm-pack is pinned to 0.12.1 as later versions are not compatible with rust 1.79 this can be removed when we upgrade to rust 1.81
@@ -53,10 +51,8 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up Rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@4a967c1422bcefedc3e9d03815f71eecdc71e5b7
         with:
-          toolchain: 1.79.0
-          override: true
           target: wasm32-unknown-unknown
 
       - name: Set up Node.js


### PR DESCRIPTION
# Why
Its defaulting to 1.81 so the crate isn't building

# How
Fix rust version like in build step
