### PR TITLE
Bump wasm version in toml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2161,7 +2161,7 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-attestation-bindings"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "attestation-doc-validation 0.10.0",
  "base64 0.22.1",

--- a/wasm-attestation-bindings/Cargo.toml
+++ b/wasm-attestation-bindings/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Evervault Engineering engineering@evervault.com"]
 edition = "2021"
 name = "wasm-attestation-bindings"
 publish = false
-version = "0.0.0"
+version = "0.1.0"
 
 [lib]
 crate-type = ["cdylib", "rlib"]


### PR DESCRIPTION
# Why
Publish for 0.1.0

# How
Bump version
