### PR TITLE
fix: update picomatch to 2.3.2 to address CVE-2026-33672

### DIFF
--- a/node-attestation-bindings/package.json
+++ b/node-attestation-bindings/package.json
@@ -28,6 +28,9 @@
   "ava": {
     "timeout": "3m"
   },
+  "resolutions": {
+    "picomatch": "^2.3.2"
+  },
   "engines": {
     "node": ">= 10"
   },

--- a/node-attestation-bindings/yarn.lock
+++ b/node-attestation-bindings/yarn.lock
@@ -1550,10 +1550,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"picomatch@npm:^2.0.4, picomatch@npm:^2.2.1, picomatch@npm:^2.3.1":
-  version: 2.3.1
-  resolution: "picomatch@npm:2.3.1"
-  checksum: 050c865ce81119c4822c45d3c84f1ced46f93a0126febae20737bd05ca20589c564d6e9226977df859ed5e03dc73f02584a2b0faad36e896936238238b0446cf
+"picomatch@npm:^2.3.2":
+  version: 2.3.2
+  resolution: "picomatch@npm:2.3.2"
+  checksum: 0a3f5b9ff28faf022e1429b66e47c122e19e7b31cbd098095d29e949684e7ff1d9b83a2133d931326a53ec6ec11c7c59b1850c27fde2f26ca1d5f35861e9701a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Overview
Resolves Linear issue **COM-114**

This PR addresses **CVE-2026-33672** (GHSA-3v7f-55p6-f55p), a prototype pollution / method injection vulnerability in picomatch.

## Vulnerability Details

| Field | Value |
|-------|-------|
| **CVE ID** | CVE-2026-33672 |
| **CVSS Score** | 5.3 (Medium) |
| **SLA Deadline** | 2026-05-25T09:39:02.973Z |
| **Affected Package** | picomatch |
| **Vulnerable Range** | < 2.3.2 |
| **Fixed Version** | 2.3.2 |

### Summary
The vulnerability stems from `POSIX_REGEX_SOURCE` inheriting from `Object.prototype`, allowing crafted POSIX bracket expressions like `[[:constructor:]]` to reference inherited method names. Those methods are coerced to strings and injected into the generated regex, potentially causing incorrect glob pattern matching.

**Impact**: Integrity — glob patterns may match unintended filenames

**Risk in this repository**: Very Low — picomatch is a transitive dependency of `ava` (a devDependency test runner), used only for development-time test file discovery with static, developer-controlled glob patterns. No user-controlled input is processed.

## Changes
- Added Yarn `resolutions` override in `package.json` to force picomatch@^2.3.2 across all dependents
- Updated `yarn.lock` to reflect picomatch@2.3.2

This is a clean patch release with no API changes or breaking updates.

## References
- [GitHub Advisory](https://github.com/micromatch/picomatch/security/advisories/GHSA-3v7f-55p6-f55p)
- [NVD Details](https://nvd.nist.gov/vuln/detail/CVE-2026-33672)
- [picomatch Fix Commit](https://github.com/micromatch/picomatch/commit/4516eb521f13a46b2fe1a1d2c9ef6b20ddc0e903)
- [Dependabot Alert](https://github.com/evervault/attestation-doc-validation/security/dependabot/51)