### PR TITLE
fix: batch simple dependency bumps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -341,9 +341,9 @@ checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
 name = "bytes"
-version = "1.10.1"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "camino"
@@ -579,12 +579,12 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.4.0"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1028,9 +1028,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.1.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-integer"
@@ -1481,10 +1481,11 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
+ "serde_core",
  "serde_derive",
 ]
 
@@ -1508,10 +1509,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_derive"
-version = "1.0.219"
+name = "serde_core"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1737,31 +1747,31 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.41"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
  "js-sys",
  "num-conv",
  "powerfmt",
- "serde",
+ "serde_core",
  "time-core",
  "time-macros",
 ]
 
 [[package]]
 name = "time-core"
-version = "0.1.4"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "time-macros"
-version = "0.2.22"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3526739392ec93fd8b359c8e98514cb3e8e021beb4e5f597b00a0221f8ed8a49"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",

--- a/node-attestation-bindings/package.json
+++ b/node-attestation-bindings/package.json
@@ -42,5 +42,9 @@
   },
   "packageManager": "yarn@3.3.1",
   "repository": "https://github.com/evervault/attestation-doc-validation",
-  "description": "Node bindings to the Evervault attestation doc validation crate"
+  "description": "Node bindings to the Evervault attestation doc validation crate",
+  "resolutions": {
+    "picomatch": "^2.3.2",
+    "lodash": "^4.17.23"
+  }
 }

--- a/node-attestation-bindings/yarn.lock
+++ b/node-attestation-bindings/yarn.lock
@@ -1164,10 +1164,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash@npm:^4.17.15":
-  version: 4.17.21
-  resolution: "lodash@npm:4.17.21"
-  checksum: eb835a2e51d381e561e508ce932ea50a8e5a68f4ebdd771ea240d3048244a8d13658acbd502cd4829768c56f2e16bdd4340b9ea141297d472517b83868e677f7
+"lodash@npm:^4.17.23":
+  version: 4.18.1
+  resolution: "lodash@npm:4.18.1"
+  checksum: bb5f5b49aad29614e709af02b64c56b0f8b78c6a81434a3c1ae527d2f0f78ca08f9d9fb22aa825a053876c9d2166e9c01f31c356014b5e2bdc0556c057433102
   languageName: node
   linkType: hard
 
@@ -1550,10 +1550,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"picomatch@npm:^2.0.4, picomatch@npm:^2.2.1, picomatch@npm:^2.3.1":
-  version: 2.3.1
-  resolution: "picomatch@npm:2.3.1"
-  checksum: 050c865ce81119c4822c45d3c84f1ced46f93a0126febae20737bd05ca20589c564d6e9226977df859ed5e03dc73f02584a2b0faad36e896936238238b0446cf
+"picomatch@npm:^2.3.2":
+  version: 2.3.2
+  resolution: "picomatch@npm:2.3.2"
+  checksum: 0a3f5b9ff28faf022e1429b66e47c122e19e7b31cbd098095d29e949684e7ff1d9b83a2133d931326a53ec6ec11c7c59b1850c27fde2f26ca1d5f35861e9701a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Overview

This PR addresses 5 simple dependency bumps to resolve known security vulnerabilities. Linear issue: **COM-138**

**Highest Severity:** MEDIUM  
**Earliest SLA:** 2026-05-25T09:39:02.973Z

---

## Vulnerabilities Fixed

### 1. CVE-2026-33672: picomatch < 2.3.2
- **Severity:** MEDIUM | CVSS: 5.3
- **SLA Deadline:** 2026-05-25T09:39:02.973Z
- **Fixed in:** 2.3.2
- **Description:** Method injection vulnerability in picomatch's POSIX_REGEX_SOURCE object. Crafted POSIX bracket expressions can inject inherited method names as strings into generated regular expressions, causing incorrect glob matching behaviour.
- **Changes:** Added `resolutions` override in `node-attestation-bindings/package.json` to force picomatch to >=2.3.2

### 2. CVE-2025-13465: lodash >= 4.0.0, <= 4.17.22
- **Severity:** MEDIUM | CVSS: 6.5
- **SLA Deadline:** 2026-05-29T18:11:52.722Z
- **Fixed in:** 4.17.23
- **Description:** Prototype pollution via `_.unset()` / `_.omit()` — allows deletion of prototype properties on global objects, potentially breaking downstream code. Lodash is a transitive dev-only dependency with no attacker-reachable path.
- **Changes:** Added `resolutions` override in `node-attestation-bindings/package.json` to force lodash to >=4.17.23 (resolved to 4.18.1)

### 3. CVE-2026-25727: rust-time >= 0.3.6, < 0.3.47
- **Severity:** MEDIUM | CVSS: 0
- **SLA Deadline:** 2026-05-29T18:11:52.722Z
- **Fixed in:** 0.3.47
- **Description:** RFC 2822 stack exhaustion DoS — crafted input to RFC 2822 date parser can exhaust the call stack. No RFC 2822 parsing paths exist in this project; risk is theoretical.
- **Changes:** Updated `Cargo.lock` via `cargo update -p time` (0.3.41 → 0.3.47)

### 4. CVE-2026-25541: rust-bytes >= 1.2.1, < 1.11.1
- **Severity:** MEDIUM | CVSS: 0
- **SLA Deadline:** 2026-05-29T18:11:52.722Z
- **Fixed in:** 1.11.1
- **Description:** Integer overflow in `BytesMut::reserve` can corrupt the capacity field in release builds with overflow-checks disabled. Transitive dependency via uniffi; no direct usage in project code.
- **Changes:** Updated `Cargo.lock` via `cargo update bytes` (1.10.1 → 1.11.1)

### 5. CVE-2025-4432: rust-ring < 0.17.12
- **Severity:** MEDIUM | CVSS: 0
- **SLA Deadline:** 2026-05-29T18:11:52.722Z
- **Fixed in:** 0.17.12
- **Description:** Integer overflow panic in QUIC header protection and large AES-GCM chunks (≥64 GB). No QUIC usage; large-chunk encryption is unreachable. Already patched at 0.17.14.
- **Changes:** Verified `Cargo.lock` already resolves to 0.17.14

---

## Testing

- Node.js: `yarn install` executed and verified resolution to patched versions
- Rust: `cargo update` executed for all affected crates
- Lock files updated and committed

All changes are purely dependency updates with no code modifications required.