### PR TITLE
Add workerThreads option to AVA configuration

### DIFF
--- a/node-attestation-bindings/package.json
+++ b/node-attestation-bindings/package.json
@@ -26,7 +26,8 @@
     "ava": "^5.2.0"
   },
   "ava": {
-    "timeout": "3m"
+    "timeout": "3m",
+    "workerThreads": false
   },
   "engines": {
     "node": ">= 10"


### PR DESCRIPTION
# Why

Disabling worker threads on ava will resolve the error in CI after tests pass blocking successful run. This is a temporary solution until we move to napi-3

# How

Known issue with worker threads and node native addons. Napi-2 doesn't exit cleanly when spawned in a worker thread due to a dependency on a global which prevents clean exit.

1. AVA 4+ (this repo pins ava ^5.2.0) runs every test file inside a worker_threads Worker by default.
2. The worker loads the napi-rs–built native addon (evervault-attestation-bindings.*.node) so the test can call attestEnclave.
3. When the worker finishes and shuts down, Node tears down the worker's V8 isolate. Native addons loaded in a worker are supposed to register an env-cleanup hook so their weak references / finalizers fire before the isolate dies — but in practice that path is fragile and frequently segfaults, especially when the addon holds JS handles (this code uses JsBuffer::into_value(), which keeps a Node reference).
4. The Worker thread crashes with SIGSEGV inside V8 / N-API teardown, which propagates to the main ava CLI process.
5. The shell sees the parent died from a signal → exit 128 + signal. Depending on whether the segfault is in the worker (SIGSEGV propagated through main → 139) or whether yarn's child‑process wrapper translates the signal (yarn 3 reports it as 129 / SIGHUP), the visible code differs — but both paths come from the same crash.