### PR TITLE
fix: drop vulnerable ring 0.16.20 by bumping rcgen 0.11 → 0.12 (CVE-2025-4432)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1303,12 +1303,12 @@ dependencies = [
 
 [[package]]
 name = "rcgen"
-version = "0.11.3"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52c4f3084aa3bc7dfbba4eff4fab2a54db4324965d8872ab933565e6fbd83bc6"
+checksum = "48406db8ac1f3cbc7dcdb56ec355343817958a356ff430259bb07baf7607e1e1"
 dependencies = [
  "pem 3.0.6",
- "ring 0.16.20",
+ "ring",
  "time",
  "yasna",
 ]
@@ -1374,21 +1374,6 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.16.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
-dependencies = [
- "cc",
- "libc",
- "once_cell",
- "spin",
- "untrusted 0.7.1",
- "web-sys",
- "winapi",
-]
-
-[[package]]
-name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
@@ -1397,7 +1382,7 @@ dependencies = [
  "cfg-if",
  "getrandom",
  "libc",
- "untrusted 0.9.0",
+ "untrusted",
  "windows-sys",
 ]
 
@@ -1653,12 +1638,6 @@ name = "siphasher"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
-
-[[package]]
-name = "spin"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spki"
@@ -1958,12 +1937,6 @@ dependencies = [
 
 [[package]]
 name = "untrusted"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
-
-[[package]]
-name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
@@ -2049,23 +2022,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "web-sys"
-version = "0.3.77"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "webpki"
 version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed63aea5ce73d0ff405984102c42de94fc55a6b75765d621c65262469b3c9b53"
 dependencies = [
- "ring 0.17.14",
- "untrusted 0.9.0",
+ "ring",
+ "untrusted",
 ]
 
 [[package]]
@@ -2076,28 +2039,6 @@ checksum = "2e79c5206e1f43a2306fd64bdb95025ee4228960f2e6c5a8b173f3caaf807741"
 dependencies = [
  "nom",
 ]
-
-[[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"

--- a/attestation-doc-validation/Cargo.toml
+++ b/attestation-doc-validation/Cargo.toml
@@ -44,7 +44,7 @@ time = { version = "0.3", features = ["wasm-bindgen"] }
 wasm-bindgen = { version = "0.2.99" }
 
 [dev-dependencies]
-rcgen = "0.11"
+rcgen = "0.12"
 base64 = "0.21"
 serde_json = "1"
 pem = "1.1.1"


### PR DESCRIPTION
Resolves [COM-214](https://linear.app/) — patches Dependabot alert [#24](https://github.com/evervault/attestation-doc-validation/security/dependabot/24).

## CVE summary

| Field | Value |
| --- | --- |
| CVE | CVE-2025-4432 |
| Affected package | `ring` (Rust) |
| Vulnerable range | `< 0.17.12` |
| Fixed in | `0.17.12` |
| Severity | MEDIUM |
| CVSS | 0 |
| SLA deadline | 2026-05-29T18:11:52.722Z |

## Why this is still open after the batch bump in #157

The previous batch bump (commit `843587a`, PR #157, Linear COM-113) moved `rcgen` from `0.10` to `0.11.3` and noted that "production ring 0.17.14 already patched". That is still true for the production graph, but `rcgen 0.11.x` still declares `ring = "0.16"` as a transitive dev-dep, so `Cargo.lock` continues to pin `ring 0.16.20`.

Dependabot keeps flagging that lockfile entry under CVE-2025-4432 because `0.16.20 < 0.17.12` by naive version comparison, even though the underlying GHSA advisory only covers the `0.17.x` line. To actually close the alert we need `ring 0.16.20` out of the lockfile entirely.

## What changed

- `attestation-doc-validation/Cargo.toml`: dev-dep `rcgen = "0.11"` → `rcgen = "0.12"`. `rcgen 0.12` depends on `ring = "^0.17"`, so cargo can unify on the already-present `ring 0.17.14`.
- `Cargo.lock`: refreshed.
  - `rcgen` `0.11.3` → `0.12.1`
  - **Removes `ring 0.16.20`** along with its transitive deps `spin 0.5.2`, `untrusted 0.7.1`, `web-sys` (unused branch), `winapi 0.3.9`, `winapi-i686-pc-windows-gnu`, `winapi-x86_64-pc-windows-gnu`
  - Only `ring 0.17.14` (≥ fixed version `0.17.12`) remains in the graph

The rcgen API surface used in tests (`generate_simple_self_signed`, `rcgen::Certificate`, `cert.serialize_der()`) is unchanged between 0.11 and 0.12, so no test code edits are needed.

## Verification

- `cargo build -p attestation-doc-validation --tests` ✅
- `cargo test -p attestation-doc-validation` — rcgen-using tests still pass: `test::test_der_cert_parsing`, `test::validate_debug_mode_attestation_doc`. The six `*_time_sensitive_*` test failures are pre-existing on `main` (embedded attestation docs are expired relative to today's date); this PR does not change them.
- `grep "ring 0.16" Cargo.lock` returns 0 matches.

## Out of scope

Not bumping to `rcgen ≥ 0.13`. 0.13 introduces a breaking API change where `Certificate` is split from `KeyPair` and `serialize_der()` is replaced by `der()` returning `CertificateDer`, both of which would require touching the test helpers in `attestation-doc-validation/src/lib.rs`. Staying at 0.12 is the minimum bump that resolves the alert.